### PR TITLE
Add ability for addMatches to interpret arrays.

### DIFF
--- a/match/match.py
+++ b/match/match.py
@@ -1,5 +1,6 @@
 import discord
 import re
+import ast
 
 from discord.ext import commands
 
@@ -13,8 +14,9 @@ class Match:
         self.CONFIG_COG = self.bot.get_cog("TransactionConfiguration")
 
     @commands.command(pass_context=True)
-    async def addMatches(self, ctx, * matchInfo):
-        for x in matchInfo:
+    async def addMatches(self, ctx, matchInfo):
+        matches = ast.literal_eval(matchInfo)
+        for x in matches:
             await self.bot.say(x)
 
     @commands.command(pass_context=True)


### PR DESCRIPTION
Found how to get this working via [Stack Overflow](https://stackoverflow.com/questions/1894269/convert-string-representation-of-list-to-list).

With the change below, I can get the results you see in this image.

<img width="316" alt="screen shot 2019-01-05 at 12 41 56 am" src="https://user-images.githubusercontent.com/112164/50721351-b5e5b080-1083-11e9-97d3-050e805697da.png">

I am pretty sure each line is itself actually an array. Assuming so, then you're in business for the 2D array you were thinking of.

Not so sure how to store the info when it is added and all of that, however. Haven't had/taken the time to read how the other commands are doing it. Something with `server_dict`, I guess? Plus I'd need the format you're wanting to use.

Note, that we could use something more like what the [Red example](https://twentysix26.github.io/Red-Docs/red_guide_make_cog/#getting-info-from-webpages) does and save the schedule as a web page (on the site) and load it from there. Might make it easier when the schedule changes. But, if you've got the example of the other way, that will probably be faster to get done.

Anyway, if I don't get the time to do the rest, hopefully this helps.