### PR TITLE
Rework match and team commands.

### DIFF
--- a/match/match.py
+++ b/match/match.py
@@ -1,215 +1,215 @@
 import traceback
-import re
 import ast
 import random
 from datetime import datetime
 import json
 
-import discord
 from discord.ext import commands
+from cogs.utils import checks
+
 
 class Match:
     """Used to get the match information"""
 
-    CONFIG_COG = None
+    DATASET = "MatchData"
+    MATCH_DAY_KEY = "MatchDay"
+    SCHEDULE_KEY = "Schedule"
+    MATHCES_KEY = "Matches"
+    TEAM_DAY_INDEX_KEY = "TeamDays"
 
     def __init__(self, bot):
         self.bot = bot
-        self.CONFIG_COG = self.bot.get_cog("TransactionConfiguration")
-        self.data = None
+        self.data_cog = self.bot.get_cog("RscData")
+        self.team_manager = self.bot.get_cog("TeamManager")
 
-    @commands.command(pass_context=True)
+    @commands.command(pass_context=True, no_pm=True)
+    async def setMatchDay(self, ctx, day: str):
+        """Sets the active match day to the specified day.
+
+        This match day is used when accessing the info in the !match command.
+        """
+        self._save_match_day(ctx, str(day))
+        await self.bot.say("Done")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def getMatchDay(self, ctx):
+        """Gets the currently active match day."""
+        match_day = self._match_day(ctx)
+        if match_day:
+            await self.bot.say(
+                "Current match day is: {0}".format(match_day))
+        else:
+            await self.bot.say(":x: Match day not set. Set with setMatchDay "
+                               "command.")
+
+    @commands.command(pass_context=True, no_pm=True)
+    @checks.admin_or_permissions(manage_server=True)
     async def printScheduleData(self, ctx):
         """Print all raw schedule data.
-        
-        Note: In the real server, this will likely fail just due to the amount 
+
+        Note: In the real server, this will likely fail just due to the amount
         of data. Intended for use in debugging on test servers. Basically,
         when there are only a handful of matches total.
-        
+
         TODO: Might even comment this out in prod.
         """
-        self.getData(ctx)
-        dump = json.dumps(self.schedule(ctx), indent=4, sort_keys=True)
+        schedule = self._schedule(ctx)
+        dump = json.dumps(schedule, indent=4, sort_keys=True)
         await self.bot.say("Here is all of the schedule data in "
                            "JSON format.\n```json\n{0}\n```".format(dump))
 
-    @commands.command(pass_context=True)
+    @commands.command(pass_context=True, no_pm=True)
+    @checks.admin_or_permissions(manage_server=True)
     async def clearSchedule(self, ctx):
         """Clear all scheduled matches."""
-        self.getData(ctx)
-        self.schedule(ctx).clear()
-        self.saveData()
+        self._save_schedule(ctx, {})
         await self.bot.say("Done.")
 
-    @commands.command(pass_context=True)
+    @commands.command(pass_context=True, no_pm=True)
     async def match(self, ctx, *args):
         """Get match info.
 
-        If no arguments are provided, retrieve the match info for the match day set
-        at the server level for the requesting user's team. This will fail if the
-        user has no team role or if the match day is not set.
-        
-        If one argument is provided, it must be the match day to retrieve. If more
-        than one argument is provided, the first must be the match day followed by
-        a list of teams for which the match info should be retrieved.
+        If no arguments are provided, retrieve the match info for the
+        server's currently active match day for the requesting user's
+        team or teams. This will fail if the user has no team role or if
+        the match day is not set.
+
+        If one argument is provided, it must be the match day to retrieve. If
+        more than one argument is provided, the first must be the match day
+        followed by a list of teams for which the match info should be
+        retrieved.
 
         Example: `!match 1 derechos "killer bees"`
 
-        Note: If no team names are sent, GMs (or anyone with multiple team roles)
-        will get matchups for all their teams. User's without a team role will get
-        nothing.
+        Note: If no team names are sent, GMs (or anyone with multiple team
+        roles) will get matchups for all their teams. User's without a team
+        role will get nothing.
         """
-        self.getData(ctx)
-        matchDay = args[0] if len(args) > 0 else self._currentMatchDay(ctx)
-        teamNamesProvided = len(args) > 1
-        userTeamRoles = self._teamRolesForUser(ctx, ctx.message.author)
-        teamRoles = await self._rolesForTeamNames(ctx, *args[1:]) if teamNamesProvided else userTeamRoles
-        teamRoleForInfo = userTeamRoles[0] if len(userTeamRoles) > 0 and not teamNamesProvided else None
+        match_day = args[0] if args else self._match_day(ctx)
+        if not match_day:
+            await self.bot.say("Match day not provided and not set for "
+                               "the server.")
+            return
+        team_roles = []
+        user_team_roles = self.team_manager.teams_for_user(
+            ctx, ctx.message.author)
 
-        if len(teamRoles) == 0:
+        team_names_provided = len(args) > 1
+        if team_names_provided:
+            team_roles = self.team_manager.teams_for_names(
+                ctx, *args[1:])
+        else:
+            team_roles = user_team_roles
+
+        if not team_roles:
             await self.bot.say("No team roles found. If you provided teams, "
                                "check the spelling. If not, you do not have "
                                "a team role.")
             return
 
-        for teamRole in teamRoles:
-            matchIndex = await self._teamDayMatchIndex(ctx, teamRole.id, matchDay)
-            if matchIndex is not None:
-                await self.bot.send_message(ctx.message.author, self._formatMatchInfo(ctx, matchIndex, teamRoleForInfo))
+        for team_role in team_roles:
+            team_role_for_info = team_role if user_team_roles else None
+            match_index = self._team_day_match_index(ctx, team_role.name,
+                                                     match_day)
+            if match_index is not None:
+                await self.bot.send_message(
+                    ctx.message.author,
+                    self._format_match_info(ctx, match_index,
+                                            team_role_for_info))
             else:
-                await self.bot.send_message(ctx.message.author, "No match on day {0} for {1}".format(matchDay, teamRole.name))
+                await self.bot.send_message(
+                    ctx.message.author,
+                    "No match on day {0} for {1}".format(match_day,
+                                                         team_role.name)
+                )
             await self.bot.delete_message(ctx.message)
 
-    @commands.command(pass_context=True)
+    @commands.command(pass_context=True, no_pm=True)
     async def addMatches(self, ctx, *matches):
         """Add the matches provided to the schedule.
 
         Arguments:
-            matches -- One or more matches in the following format:
-                "['<matchDay>','<matchDate>','<home>','<away>','<roomName>','<roomPassword>']"
-                Each match should be separated by a space. Also, matchDate should be
-                formatted with the full month name, day of month and 4-digit year.
-                The room name and password are optional. They will be generated if absent.
-                Note that the placment of the double versus single quotes is important, as
-                is the comma after the day of month.
 
-            Examples:
-            ```
-                [p]addMatches "['1','September 10, 2018','Fire Ants','Leopards','octane','worst car']"
-                [p]addMatches "['1','September 10, 2018','Fire Ants','Leopards']" "['2','September 13, 2018','Leopards','Fire Ants']"
-            ```
+        matches -- One or more matches in the following format:
+        ```
+        "['<matchDay>','<matchDate>','<home>','<away>','<roomName>','<roomPassword>']"
+        ```
+        Each match should be separated by a space. Also, matchDate should be
+        formatted with the full month name, day of month and 4-digit year.
+        The room name and password are optional. They will be generated if
+        absent. Note that the placment of the double versus single quotes is
+        important, as is the comma after the day of month.
+
+        Examples:
+        ```
+        [p]addMatches "['1','September 10, 2018','Fire Ants','Leopards',
+        'octane','worst car']"
+        [p]addMatches "['1','September 10, 2018','Fire Ants','Leopards']" "[
+        '2','September 13, 2018','Leopards','Fire Ants']"
+        ```
         """
-        self.getData(ctx)
         addedCount = 0
-        for matchStr in matches:
-            match = ast.literal_eval(matchStr)
-            await self.bot.say("Adding match: {0}".format(repr(match)))
-            await self._addMatch(ctx, *match)
-            addedCount += 1
         try:
-            self.saveData()
+            for matchStr in matches:
+                match = ast.literal_eval(matchStr)
+                await self.bot.say("Adding match: {0}".format(repr(match)))
+                resultMatch = await self._add_match(ctx, *match)
+                if resultMatch:
+                    addedCount += 1
+        finally:
             await self.bot.say("Added {0} match(es).".format(addedCount))
-        except:
-            await self.bot.say(":x: Error trying to add matches.")
-            raise
 
-    @commands.command(pass_context=True)
-    async def teamList(self, ctx, teamName : str):
-        teamRole = self._roleForTeamName(ctx, teamName)
-        if teamRole is None:
-            await self.bot.say(":x: Could not match {0} to a role".format(teamName))
-            return
-        await self.bot.say(self._formatTeamInfo(ctx, teamRole))
-        return
-
-    @commands.command(pass_context=True)
-    async def setMatchDay(self, ctx, day : int):
-        """Sets the match day to the specified day.
-        
-        This match day is used when accessing the info in the !match command.
-        """
-        self.getData(ctx)
-        self.data["Match Day"] = day
-        try:
-            self.saveData()
-            await self.bot.say("Done")
-        except:
-            await self.bot.say(":x: Error trying to set the match day. Make "
-                               "sure that the transaction configuration cog "
-                               "is loaded")
-
-    @commands.command(pass_context=True)
-    async def getMatchDay(self, ctx):
-        """Gets the transaction-log channel"""
-        self.getData(ctx)
-        try:
-            await self.bot.say("Match day set to: {0}".format(self._currentMatchDay(ctx)))
-        except:
-            await self.bot.say(":x: Match day not set")
-
-    @commands.command(pass_context=True)
-    async def addMatch(self, ctx, matchDay, matchDate, home, away, *args):
+    @commands.command(pass_context=True, no_pm=True)
+    async def addMatch(self, ctx, match_day, match_date, home, away, *args):
         """Adds a single match to the schedule.
-        
+
         Arguments:
             ctx -- the bot context
-            matchDay -- the matchDay to add the match to
-            matchDate -- the date the match should be played
+            match_day -- the match_day to add the match to
+            match_date -- the date the match should be played
             home -- the home team (must match the role name)
             away -- the away team (must match the role name)
             roomName -- (optional) the name for the RL match lobby,
                         Autogenerated if not provided.
             roomPass -- (optional) the password for the match lobby.
-                        Autogenerated if not provided. 
+                        Autogenerated if not provided.
         Note: Any "extra" arguments are ignored.
         """
-        self.getData(ctx)
-        match = await self._addMatch(ctx, matchDay, matchDate, home, away, *args)
+        match = await self._add_match(ctx, match_day, match_date,
+                                      home, away, *args)
         if match:
-            message = "Saving match for: \n"
-            message += "  Match day: {0} ({1})\n".format(match['matchDay'], match['matchDate'])
-            message += "  Home team: {0}\n".format(match['home'])
-            message += "  Away team: {0}\n".format(match['away'])
-            message += "  Room name/pass: {0}/{1}".format(match['roomName'], match['roomPass'])
-            await self.bot.say(message)
-        try:
-            self.saveData()
             await self.bot.say("Done")
-        except Exception as err:
-            await self.bot.say(":x: Error trying to add match data. Make sure "
-                               "the transactionConfiguration cog is loaded.")
-            await self.bot.say("Error was: {0}".format(err))
-            await self.bot.say("Error info: {0}".format(traceback.format_exc()))
 
-    async def _addMatch(self, ctx, matchDay, matchDate, home, away, *args):
-        # Process inputs to normalize the data (e.g. convert team names to roles)
-        matchDateError = None
+    async def _add_match(self, ctx, match_day, match_date, home, away, *args):
+        """Does the actual work to save match data."""
+        # Process inputs to normalize the data (e.g. convert team names to
+        # roles)
+        match_date_error = None
         try:
-            datetime.strptime(matchDate, '%B %d, %Y').date()
+            datetime.strptime(match_date, '%B %d, %Y').date()
         except Exception as err:
-            matchDateError = "Date not valid: {0}".format(err)
-        homeRole = self._roleForTeamName(ctx, home)
-        awayRole = self._roleForTeamName(ctx, away)
-        roomName = args[0] if len(args) > 0 else self._generateNamePass()
-        roomPass = args[1] if len(args) > 1 else self._generateNamePass()
+            match_date_error = "Date not valid: {0}".format(err)
+        homeRole = self.team_manager.team_for_name(ctx, home)
+        awayRole = self.team_manager.team_for_name(ctx, away)
+        roomName = args[0] if args else self._generate_name_pass()
+        roomPass = args[1] if len(args) > 1 else self._generate_name_pass()
 
         # Validation of input
         # There are other validations we could do, but don't
-        #     - matchDay is a number
         #     - that there aren't extra args
         errors = []
-        if matchDateError:
+        if match_date_error:
             errors.append("Date provided is not valid. "
                           "(Make sure to use the right format.)")
         if not homeRole:
             errors.append("Home team role not found.")
         if not awayRole:
             errors.append("Away team role not found.")
-        if len(errors) > 0:
+        if errors:
             await self.bot.say(":x: Errors with input:\n\n  "
                                "* {0}\n".format("\n  * ".join(errors)))
             return
-        
+
         # Schedule "schema" in pseudo-JSON style:
         # "schedule": {
         #   "matches": [ <list of all matches> ],
@@ -217,198 +217,152 @@ class Match:
         #                 match days with list of indexes of all matches> }
         # }
 
+        # Load the data we will use. Race conditions are possible, but
+        # our change will be consistent, it might just override what someone
+        # else does if they do it at roughly the same time.
+        schedule = self._schedule(ctx)
         # Check for pre-existing matches
-        homeMatchIndex = await self._teamDayMatchIndex(ctx, homeRole.id, matchDay)
-        awayMatchIndex = await self._teamDayMatchIndex(ctx, awayRole.id, matchDay)
+        home_match_index = self._team_day_match_index(
+            ctx, homeRole.name, match_day)
+        away_match_index = self._team_day_match_index(
+            ctx, awayRole.name, match_day)
         errors = []
-        if homeMatchIndex is not None:
-            errors.append("Home team already has a match for match day {0}".format(matchDay))
-        if awayMatchIndex is not None:
-            errors.append("Away team already has a match for match day {0}".format(matchDay))
-        if len(errors) > 0:
-            await self.bot.say(":x: Could not create match:\n\n  * {0}\n".format("\n  * ".join(errors)))
+        if home_match_index is not None:
+            errors.append("Home team already has a match for "
+                          "match day {0}".format(match_day))
+        if away_match_index is not None:
+            errors.append("Away team already has a match for "
+                          "match day {0}".format(match_day))
+        if errors:
+            await self.bot.say(":x: Could not create match:\n"
+                               "\n  * {0}\n".format("\n  * ".join(errors)))
             return
 
-        matchData = {
-            'matchDay': matchDay,
-            'matchDate': matchDate,
-            'home': homeRole.id,
-            'away': awayRole.id,
+        match_data = {
+            'matchDay': match_day,
+            'matchDate': match_date,
+            'home': homeRole.name,
+            'away': awayRole.name,
             'roomName': roomName,
             'roomPass': roomPass
         }
 
         # Append new match and create an index in "teamDays" for both teams.
-        allMatches = self.getAllMatches(ctx)
-        teamDays = self.getTeamDays(ctx)
-        teamDays[self._keyForTeamDay(homeRole.id, matchDay)] = len(allMatches)
-        teamDays[self._keyForTeamDay(awayRole.id, matchDay)] = len(allMatches)
-        await self.bot.say("allMatches before: {0}".format(allMatches))
-        allMatches.append(matchData)
-        await self.bot.say("allMatches after: {0}".format(self.getAllMatches(ctx)))
+        matches = schedule.setdefault(self.MATHCES_KEY, [])
+        team_days = schedule.setdefault(self.TEAM_DAY_INDEX_KEY, {})
 
-        result = matchData.copy()
+        home_key = self._team_day_key(homeRole.name, match_day)
+        team_days[home_key] = len(matches)
+
+        away_key = self._team_day_key(awayRole.name, match_day)
+        team_days[away_key] = len(matches)
+
+        matches.append(match_data)
+
+        self._save_schedule(ctx, schedule)
+
+        result = match_data.copy()
         result['home'] = homeRole.name
         result['away'] = awayRole.name
         return result
 
-    def getData(self, ctx):
-        if self.data is None:
-            print("Reloading data.")
-            self.data = self.CONFIG_COG.get_server_dict(ctx)
-        return self.data
+    def _all_data(self, ctx):
+        return self.data_cog.load(ctx, self.DATASET)
 
-    def saveData(self):
-        print("Saving data: {0}".format(self.data))
-        self.CONFIG_COG.save_data()
-        self.data = None
+    def _schedule(self, ctx):
+        return self._all_data(ctx).setdefault(self.SCHEDULE_KEY, {})
 
-    def schedule(self, ctx):
-        return self.getData(ctx).setdefault('schedule', {})
+    def _save_schedule(self, ctx, schedule):
+        all_data = self._all_data(ctx)
+        all_data[self.SCHEDULE_KEY] = schedule
+        self.data_cog.save(ctx, self.DATASET, all_data)
 
-    def getTeamDays(self, ctx):
-        return self.schedule(ctx).setdefault('teamDays', {})
+    def _matches(self, ctx):
+        return self._schedule(ctx).setdefault(self.MATHCES_KEY, {})
 
-    def getAllMatches(self, ctx):
-        return self.schedule(ctx).setdefault('matches', [])
+    def _save_matches(self, ctx, matches):
+        schedule = self._schedule(ctx)
+        schedule[self.MATHCES_KEY] = matches
+        self._save_schedule(ctx, schedule)
 
-    def _currentMatchDay(self, ctx):
-        server_dict = self.CONFIG_COG.get_server_dict(ctx)
-        return server_dict["Match Day"]
+    def _team_days_index(self, ctx):
+        return self._schedule(ctx).setdefault(self.TEAM_DAY_INDEX_KEY, {})
 
-    async def _teamDayMatchIndex(self, ctx, teamRoleId, matchDay):
-        teamDays = self.getTeamDays(ctx)
-        await self.bot.say("teamDays: {0}".format(teamDays))
-        result = teamDays.get(self._keyForTeamDay(teamRoleId, matchDay))
-        await self.bot.say("teamDayMatchIndex: {0}".format(result))
-        return result
+    def _save_team_days_index(self, ctx, team_days_index):
+        schedule = self._schedule(ctx)
+        schedule[self.TEAM_DAY_INDEX_KEY] = team_days_index
+        self._save_schedule(ctx, schedule)
 
-    def _keyForTeamDay(self, teamRoleId, matchDay):
-        return "{0}|{1}".format(teamRoleId, matchDay)
+    def _match_day(self, ctx):
+        return self._all_data(ctx).setdefault(self.MATCH_DAY_KEY, 0)
 
-    async def _rolesForTeamNames(self, ctx, *teamNames):
-        """Retrieve the matching roles for the provided team names.
-        
-        Names with no matching roles are skipped. If none are found, an empty
-        list is returned.
-        """
-        roles = []
-        for teamName in teamNames:
-            role = self._roleForTeamName(ctx, teamName)
-            if role:
-                roles.append(role)
-            else:
-                await self.bot.say('Team not found: "{0}"'.format(teamName))
-        return roles
+    def _save_match_day(self, ctx, match_day):
+        all_data = self._all_data(ctx)
+        all_data[self.MATCH_DAY_KEY] = match_day
+        self.data_cog.save(ctx, self.DATASET, all_data)
 
-    def _roleForTeamName(self, ctx, teamName):
-        """ Retrieve the matching role for the provided team name.
-        
-        Returns None if there is no match.
-        """
-        roles = ctx.message.server.roles
-        for role in roles:
-            # Do we want `startswith` here? Leaving it as it is what was used before
-            if role.name.lower().startswith(teamName.lower()):
-                return role
-        return None
-    
-    def _gmAndMembersFromTeamRole(self, ctx, teamRole):
-        gm = None
-        teamMembers = []
-        for member in ctx.message.server.members:
-            if teamRole in member.roles:
-                if self.CONFIG_COG.find_role_by_name(member.roles, "General Manager") is not None:
-                    gm = member
-                else:
-                    teamMembers.append(member)
-        return (gm, teamMembers)
+    def _team_day_match_index(self, ctx, team, match_day):
+        team_days_index = self._team_days_index(ctx)
+        return team_days_index.get(
+            self._team_day_key(team, match_day))
 
-    def _formatTeamMemberForMessage(self, member, *args):
-        extraRoles = list(args)
+    def _team_day_key(self, team, match_day):
+        return "{0}|{1}".format(team, match_day)
 
-        name = member.nick if member.nick else member.name
-        if self.CONFIG_COG.find_role_by_name(member.roles, "Captain") is not None:
-            extraRoles.append("C")
-        roleString = "" if len(extraRoles) == 0 else " ({0})".format("|".join(extraRoles))
-        return "{0}{1}".format(name, roleString)
-
-    def _formatMatchInfo(self, ctx, matchIndex, userTeamRole=None):
-        allMatches = self.getAllMatches(ctx)
-        match = allMatches[matchIndex]
+    def _format_match_info(self, ctx, match_index, user_team_role=None):
+        matches = self._matches(ctx)
+        match = matches[match_index]
         # Match format:
-        # matchData = {
-        #     'matchDay': matchDay,
-        #     'matchDate': matchDate,
-        #     'home': homeRole.id,
-        #     'away': awayRole.id,
+        # match_data = {
+        #     'matchDay': match_day,
+        #     'matchDate': match_date,
+        #     'home': homeRole.name,
+        #     'away': awayRole.name,
         #     'roomName': roomName,
         #     'roomPass': roomPass
         # }
-        roles = ctx.message.server.roles
-        home = self.CONFIG_COG.find_role(roles, match['home'])
-        away = self.CONFIG_COG.find_role(roles, match['away'])
-        message = "__Match Day {0}: {1}__\n".format(match['matchDay'], match['matchDate'])
-        message += "**{0}**\n    versus\n**{1}**\n\n".format(home.name, away.name)
-        message += "Room Name: **{0}**\nPassword: **{1}**\n".format(match['roomName'], match['roomPass'])
-        if userTeamRole and userTeamRole == home:
-            message += ("\nYou are the **home** team. You will create the room "
-                        "using the above information. Contact the other team "
-                        "when your team is ready to begin the match. Do not "
-                        "join a team until the away team starts to.\n"
+        home = self.team_manager.team_for_name(ctx, match['home'])
+        away = self.team_manager.team_for_name(ctx, match['away'])
+        message = "__Match Day {0}: {1}__\n".format(match['matchDay'],
+                                                    match['matchDate'])
+        message += "**{0}**\n    versus\n**{1}**\n\n".format(home.name,
+                                                             away.name)
+        message += ("Room Name: **{0}**\nPassword: "
+                    "**{1}**\n").format(match['roomName'], match['roomPass'])
+        if user_team_role and user_team_role == home:
+            message += ("\nYou are the **home** team. You will create the "
+                        "room using the above information. Contact the "
+                        "other team when your team is ready to begin the "
+                        "match. Do not join a team until the away team starts "
+                        "to.\n"
                         "Remember to ask before the match begins if the other "
-                        "team would like to switch server region after 2 games.")
-        elif userTeamRole and userTeamRole == away:
-            message += ("\nYou are the **away** team. You will join the room using "
-                       "the above information once the other team contacts "
-                       "you. Do not begin joining a team until your entire "
-                       "team is ready to begin playing.")
-        # TODO: Add other info (complaint form, disallowed maps, enable crossplay, etc.)
+                        "team would like to switch server region after 2 "
+                        "games.")
+        elif user_team_role and user_team_role == away:
+            message += ("\nYou are the **away** team. You will join the room "
+                        "using the above information once the other team "
+                        "contacts you. Do not begin joining a team until "
+                        "your entire team is ready to begin playing.")
+
+        # TODO: Add other info (complaint form, disallowed maps,
+        #       enable crossplay, etc.)
         message += "\n\n*Other info here*\n\n"
+
         message += "**Home Team:**\n"
-        message += self._formatTeamInfo(ctx, home)
+        message += self.team_manager.format_team_info(ctx, home)
         message += "\n**Away Team:**\n"
-        message += self._formatTeamInfo(ctx, away)
+        message += self.team_manager.format_team_info(ctx, away)
 
         return message
 
-    def _formatTeamInfo(self, ctx, teamRole):
-        gm, teamMembers = self._gmAndMembersFromTeamRole(ctx, teamRole)
-        
-        message = "```\n{0}:\n".format(teamRole.name)
-        if gm:
-            message += "  {0}\n".format(self._formatTeamMemberForMessage(gm, "GM"))
-        for member in teamMembers:
-            message += "  {0}\n".format(self._formatTeamMemberForMessage(member))
-        message += "```\n"
-        return message
-
-    def _teamRolesForUser(self, ctx, user):
-        tierList = self.CONFIG_COG.get_tier_list(ctx)
-        teamRoles = []
-        for role in user.roles:
-            tierName = self._extractTierFromTeamRole(role)
-            if tierName is not None:
-                if tierName in tierList:
-                    teamRoles.append(role)
-        return teamRoles
-
-    def _extractTierFromTeamRole(self, teamRole):
-        try:
-            return re.findall(r'\w*\b(?=\))', teamRole.name)[0]
-        except:
-            return None
-
-
-    
-    def _generateNamePass(self):
+    def _generate_name_pass(self):
         # TODO: Load from file?
         set = [
             'octane', 'takumi', 'dominus', 'hotshot', 'batmobile', 'mantis',
             'paladin', 'twinmill', 'centio', 'breakout', 'animus', 'venom',
             'xdevil', 'endo', 'masamune', 'merc', 'backfire', 'gizmo',
             'roadhog', 'armadillo', 'hogsticker', 'luigi', 'mario', 'samus',
-            'sweettooth', 'cyclone', 'imperator', 'jager', 'mantis', 'nimbus', 
+            'sweettooth', 'cyclone', 'imperator', 'jager', 'mantis', 'nimbus',
             'samurai', 'twinzer', 'werewolf', 'maverick', 'artemis', 'charger',
             'skyline', 'aftershock', 'boneshaker', 'delorean', 'esper',
             'fast4wd', 'gazella', 'grog', 'jeep', 'marauder', 'mclaren',
@@ -426,7 +380,7 @@ class Match:
 
             'ara51', 'ballacarra', 'chrono', 'clockwork', 'cruxe',
             'discotheque', 'draco', 'dynamo', 'equalizer', 'gernot', 'hikari',
-            'hypnotik','illuminata','infinium', 'kalos', 'lobo', 'looper',
+            'hypnotik', 'illuminata', 'infinium', 'kalos', 'lobo', 'looper',
             'photon', 'pulsus', 'raijin', 'reactor', 'roulette', 'turbine',
             'voltaic', 'wonderment', 'zomba',
 
@@ -441,13 +395,20 @@ class Match:
             'casper', 'caveman', 'centice', 'chipper', 'cougar', 'dude',
             'foamer', 'fury', 'gerwin', 'goose', 'heater', 'hollywood',
             'hound', 'iceman', 'imp', 'jester', 'junker', 'khan', 'marley',
-            'maverick', 'merlin', 'middy', 'mountain', 'myrtle', 'outlaw', 
+            'maverick', 'merlin', 'middy', 'mountain', 'myrtle', 'outlaw',
             'poncho', 'rainmaker', 'raja', 'rex', 'roundhouse', 'sabretooth',
             'saltie', 'samara', 'scout', 'shepard', 'slider', 'squall',
             'sticks', 'stinger', 'storm', 'sultan', 'sundown', 'swabbie',
             'tex', 'tusk', 'viper', 'wolfman', 'yuri'
         ]
         return set[random.randrange(len(set))]
+
+    def log_info(self, message):
+        self.data_cog.logger().info("[Match] " + message)
+
+    def log_error(self, message):
+        self.data_cog.logger().error("[Match] " + message)
+
 
 def setup(bot):
     bot.add_cog(Match(bot))

--- a/rscdata/rscdata.py
+++ b/rscdata/rscdata.py
@@ -1,0 +1,107 @@
+import os.path
+import os
+import json
+import logging
+
+from .utils.dataIO import dataIO
+from discord.ext import commands
+from cogs.utils import checks
+
+
+class RscData:
+    """Utility cog for storing and retrieving data.
+
+    Currently just writes JSON to files. Could be changed to another file
+    format or, in theory, to use an actual database.
+    """
+    DATA_FOLDER = "data/rscdata"
+    LOG_FILE = DATA_FOLDER + "/rsc.log"
+
+    DATA_BOOTSTRAP = {}
+    SERVERLESS = "no_server"
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(pass_context=True)
+    @checks.admin_or_permissions(manage_server=True)
+    async def dumpDataset(self, ctx, dataset):
+        json_dump = json.dumps(
+            self.load(ctx, dataset), indent=4, sort_keys=True)
+        await self.bot.say("Dataset: {0}\n{1}".format(dataset, json_dump))
+
+    def load(self, ctx, dataset):
+        """Return the data for the named dataset in the server from the
+        supplied context."""
+        return self._load_data(ctx, dataset)
+
+    def save(self, ctx, dataset, data):
+        """Save the provided data into the named dataset in the server
+        for the provided context.
+
+        The current implementation completely overwrites the specified
+        dataset.
+        """
+        self._save_data(ctx, dataset, data)
+
+    def logger(self):
+        return logger
+
+    def _dataset_file(self, dataset):
+        return "{0}/{1}.json".format(self.DATA_FOLDER, dataset)
+
+    def _ensure_dataset_file(self, dataset):
+        """Create the specified file if it does not exist."""
+        dataset_file = self._dataset_file(dataset)
+        if not dataIO.is_valid_json(dataset_file):
+            dataIO.save_json(dataset_file, self.DATA_BOOTSTRAP)
+
+    def _server_set_for(self, ctx):
+        """Return the name of the dict to be used for the server in the
+        provided context."""
+        if ctx.message.server:
+            return str(ctx.message.server.id)
+        else:
+            return self.SERVERLESS
+
+    def _load_data(self, ctx, dataset):
+        """Load the data dictionary from the file."""
+        all_data = self._all_data(dataset)
+        server_set = self._server_set_for(ctx)
+        data = all_data.setdefault(server_set, self.DATA_BOOTSTRAP)
+        return data
+
+    def _save_data(self, ctx, dataset, data):
+        """Save the data into the dataset within the context provided.
+
+        This overwrites any pre-existing data.
+        """
+        server_set = self._server_set_for(ctx)
+        all_data = self._all_data(dataset)
+        all_data[server_set] = data
+        dataIO.save_json(self._dataset_file(dataset), all_data)
+
+    def _all_data(self, dataset):
+        self._ensure_dataset_file(dataset)
+        return dataIO.load_json(self._dataset_file(dataset))
+
+
+def ensure_data_folder():
+    """Create the needed data folder if it does not exist."""
+    if not os.path.exists(RscData.DATA_FOLDER):
+        os.makedirs(RscData.DATA_FOLDER, exist_ok=True)
+
+
+def setup(bot):
+    global logger
+    ensure_data_folder()
+    logger = logging.getLogger("rsc.data")
+    if logger.level == 0:
+        # Prevents the logger from being loaded again in case of module reload
+        logger.setLevel(logging.INFO)
+        handler = logging.FileHandler(
+            filename=RscData.LOG_FILE, encoding='utf-8', mode='a')
+        handler.setFormatter(logging.Formatter(
+            '%(asctime)s %(message)s', datefmt="[%d/%m/%Y %H:%M]"))
+        logger.addHandler(handler)
+    bot.add_cog(RscData(bot))

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -1,0 +1,170 @@
+import re
+
+from discord.ext import commands
+
+
+class TeamManager:
+    """Used to get the match information"""
+
+    DATASET = "TeamData"
+    TIERS_KEY = "Tiers"
+    GM_ROLE = "General Manager"
+    CAPTAN_ROLE = "Captain"
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.data_cog = self.bot.get_cog("RscData")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def teamList(self, ctx, teamName: str):
+        team_role = self.team_for_name(ctx, teamName)
+        if team_role is None:
+            await self.bot.say(
+                ":x: Could not match {0} to a role".format(teamName))
+            return
+        await self.bot.say(self.format_team_info(ctx, team_role))
+        return
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def tierList(self, ctx):
+        tiers = self._tiers(ctx)
+        if tiers:
+            await self.bot.say(
+                "Tiers set up in this server: {0}".format(", ".join(tiers)))
+        else:
+            await self.bot.say("No tiers set up in this server.")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def addTier(self, ctx, tier_name: str):
+        tiers = self._tiers(ctx)
+        tiers.append(tier_name)
+        self._save_tiers(ctx, tiers)
+        await self.bot.say("Done.")
+
+    @commands.command(pass_context=True, no_pm=True)
+    async def removeTier(self, ctx, tier_name: str):
+        tiers = self._tiers(ctx)
+        try:
+            tiers.remove(tier_name)
+        except ValueError:
+            await self.bot.say(
+                "{0} does not seem to be a tier.".format(tier_name))
+            return
+        self._save_tiers(ctx, tiers)
+        await self.bot.say("Done.")
+
+    def is_gm(self, member):
+        for role in member.roles:
+            if role.name == self.GM_ROLE:
+                return True
+        return False
+
+    def is_captain(self, member):
+        for role in member.roles:
+            if role.name == self.CAPTAN_ROLE:
+                return True
+        return False
+
+    def teams_for_user(self, ctx, user):
+        tiers = self._tiers(ctx)
+        team_roles = []
+        for role in user.roles:
+            tier = self._extract_tier_from_role(role)
+            if tier is not None:
+                if tier in tiers:
+                    team_roles.append(role)
+        return team_roles
+
+    def teams_for_names(self, ctx, *team_names):
+        """Retrieve the matching team roles for the provided names.
+
+        Names with no matching roles are skipped. If none are found, an empty
+        list is returned.
+        """
+        teams = []
+        for team_name in team_names:
+            team = self.team_for_name(ctx, team_name)
+            if team:
+                teams.append(team)
+        return teams
+
+    def team_for_name(self, ctx, team_name):
+        """ Retrieve the matching team role for the provided name.
+
+        Returns None if there is no match.
+        """
+        roles = ctx.message.server.roles
+        for role in roles:
+            # Do we want `startswith` here? Leaving it as it is what was
+            # used before
+            if role.name.lower().startswith(team_name.lower()):
+                return role
+        return None
+
+    def gm_and_members_from_team(self, ctx, team_role):
+        """Retrieve tuple with the gm user and a list of other users that are
+        on the team indicated by the provided team_role.
+        """
+        gm = None
+        team_members = []
+        for member in ctx.message.server.members:
+            if team_role in member.roles:
+                if self.is_gm(member):
+                    gm = member
+                else:
+                    team_members.append(member)
+        return (gm, team_members)
+
+    def format_team_info(self, ctx, team_role):
+        gm, team_members = self.gm_and_members_from_team(ctx, team_role)
+
+        message = "```\n{0}:\n".format(team_role.name)
+        if gm:
+            message += "  {0}\n".format(
+                self._format_team_member_for_message(gm, "GM"))
+        for member in team_members:
+            message += "  {0}\n".format(
+                self._format_team_member_for_message(member))
+        if not team_members:
+            message += "  No known members."
+        message += "```\n"
+        return message
+
+    def _format_team_member_for_message(self, member, *args):
+        extraRoles = list(args)
+
+        name = member.nick if member.nick else member.name
+        if self.is_captain(member):
+            extraRoles.append("C")
+        roleString = ""
+        if extraRoles:
+            roleString = " ({0})".format("|".join(extraRoles))
+        return "{0}{1}".format(name, roleString)
+
+    def _all_data(self, ctx):
+        all_data = self.data_cog.load(ctx, self.DATASET)
+        return all_data
+
+    def _tiers(self, ctx):
+        all_data = self._all_data(ctx)
+        tiers = all_data.setdefault(self.TIERS_KEY, [])
+        return tiers
+
+    def _save_tiers(self, ctx, tiers):
+        all_data = self._all_data(ctx)
+        all_data[self.TIERS_KEY] = tiers
+        self.data_cog.save(ctx, self.DATASET, all_data)
+
+    def _extract_tier_from_role(self, team_role):
+        tier_matches = re.findall(r'\w*\b(?=\))', team_role.name)
+        return None if not tier_matches else tier_matches[0]
+
+    def log_info(self, message):
+        self.data_cog.logger().info("[TeamManager] " + message)
+
+    def log_error(self, message):
+        self.data_cog.logger().error("[TeamManager] " + message)
+
+
+def setup(bot):
+    bot.add_cog(TeamManager(bot))


### PR DESCRIPTION
This is a pretty significant change to the way data is being saved. I
have not done anything with commands that were not in the `match` cog, but
the `match` cog no longer uses the `transactionConfiguration` cog to help it load or
store data. Instead, it uses a new `rscdata` cog. 

This new cog creates separate data files per "dataset", which is currently separated by cog. So, `match` has a `MatchData.json` file in the rscdata directory. The new cog `teamManager` also has a
file there: `TeamData.json`.

The `teamManager` cog is new. It has the following commands:

* teamList
* tierList
* addTier
* removeTier

This cog also has some helpful team-related methods for other cogs. For example `team_for_name`, which does pretty much what it says on the tin.

I have tested all of the commands on my test server, but that server doesn't have a ton of roles, and only has me and the bot as users. More testing is recommended. :-)

Note: This does make installing everything a bit more painful as there are now two additional cogs to install. I think the improved organization of things is worth it. For example, we will be better prepared if we ever want to change how we store the data. That should be possible by just changing the `rscdata` cog without touching the others unless we want to go to a full RDBMS, which could be a fun challenge. (I know Memlo was wanting to use YAML. I don't prefer one or the other, but JSON for now as that is built-in to the dataIO cog that we use and Python has good library support built-in.)