### PR TITLE
First day patch for sixMans cog

### DIFF
--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -13,7 +13,7 @@ from redbot.core.utils.predicates import ReactionPredicate
 from redbot.core.utils.menus import start_adding_reactions
 
 team_size = 6
-minimum_game_time = 900 #Seconds (15 Minutes)
+minimum_game_time = 600 #Seconds (10 Minutes)
 pp_play_key = "Play"
 pp_win_key = "Win"
 player_points_key = "Points"
@@ -210,13 +210,13 @@ class SixMans(commands.Cog):
     @commands.command(aliases=["sr"])
     async def scoreReport(self, ctx, winning_team):
         """Report which team won the series. Can only be used in a 6Mans game channel.
-        Only valid after 15 minutes have passed since the game started. Both teams will need to verify the results.
+        Only valid after 10 minutes have passed since the game started. Both teams will need to verify the results.
 
         `winning_team` must be either `Blue` or `Orange`"""
         await self._pre_load_queues(ctx)
         game_time = ctx.message.created_at - ctx.channel.created_at
         if game_time.seconds < minimum_game_time:
-            await ctx.send(":x: You can't report a game outcome until at least **15 minutes** have passed since the game has started."
+            await ctx.send(":x: You can't report a game outcome until at least **10 minutes** have passed since the game has started."
                 "\nCurrent time that's passed = **{0} minute(s)**".format(game_time.seconds // 60))
             return
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -354,7 +354,7 @@ class SixMans(commands.Cog):
             return
 
         sorted_players = sorted(players.items(), key=lambda x: x[1][player_wins_key], reverse=True)
-        sorted_players = sorted(sorted_players.items(), key=lambda x: x[1][player_points_key], reverse=True)
+        sorted_players = sorted(sorted_players, key=lambda x: x[1][player_points_key], reverse=True)
         await ctx.send(embed=await self._format_leaderboard(ctx, sorted_players, six_mans_queue))
 
     @commands.guild_only()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -216,7 +216,7 @@ class SixMans(commands.Cog):
         await self._pre_load_queues(ctx)
         game_time = ctx.message.created_at - ctx.channel.created_at
         if game_time.seconds < minimum_game_time:
-            await ctx.send(":x: You can't report a game outcome until at least **10 minutes** have passed since the game has started."
+            await ctx.send(":x: You can't report a game outcome until at least **10 minutes** have passed since the game was created."
                 "\nCurrent time that's passed = **{0} minute(s)**".format(game_time.seconds // 60))
             return
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -557,8 +557,12 @@ class SixMans(commands.Cog):
         return embed
 
     def _format_queue(self, ctx, queue):
+        player_list = "".format(", ".join([player.mention for player in queue.queue.queue]))
+        if player_list == "":
+            player_list = "No players currently in the queue"
+
         embed = discord.Embed(title="{0} 6 Mans Queue".format(queue.name), color=discord.Colour.blue())
-        embed.add_field(name="Players in Queue", value="{}\n".format(", ".join([player.mention for player in queue.queue.queue])), inline=False)
+        embed.add_field(name="Players in Queue", value=player_list, inline=False)
         return embed
 
     async def _pre_load_queues(self, ctx):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -435,9 +435,10 @@ class SixMans(commands.Cog):
         embed.add_field(name="Additional Info", value="Feel free to play whatever type of series you want, whether a bo3, bo5, or any other.\n\n"
             "When you are done playing with the current teams please report the winning team using the command `{0}sr [winning_team]` where "
             "the `winning_team` parameter is either `Blue` or `Orange`. Both teams will need to verify the results.\n\nIf you wish to cancel "
-            "the game and allow players to queue again you can use the `{0}cg` command. Both teams will need to verify that they wish to cancel the game.", inline=False)
+            "the game and allow players to queue again you can use the `{0}cg` command. Both teams will need to verify that they wish to "
+            "cancel the game.".format(ctx.prefix), inline=False)
         embed.add_field(name="Help", value="If you need any help or have questions please contact an Admin. "
-            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.".format(ctx.prefix), inline=False)
+            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.", inline=False)
         await game.channel.send(embed=embed)
 
     async def _create_game(self, ctx, six_mans_queue):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -417,7 +417,7 @@ class SixMans(commands.Cog):
         
         embed = discord.Embed(title="{0} 6 Mans Leaderboard".format(queue_name), color=discord.Colour.blue())
         embed.add_field(name="Games Played", value="{}\n".format(games_played), inline=True)
-        embed.add_field(name="Unique Players All-Time", value="{}\n".format(len(sorted_players), inline=True)
+        embed.add_field(name="Unique Players All-Time", value="{}\n".format(len(sorted_players)), inline=True)
         
         index = 1
         message = ""

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -557,7 +557,7 @@ class SixMans(commands.Cog):
         return embed
 
     def _format_queue(self, ctx, queue):
-        player_list = "".format(", ".join([player.mention for player in queue.queue.queue]))
+        player_list = "{}".format(", ".join([player.mention for player in queue.queue.queue]))
         if player_list == "":
             player_list = "No players currently in the queue"
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -130,7 +130,7 @@ class SixMans(commands.Cog):
 
     @commands.guild_only()
     @commands.command(aliases=["cq"])
-    async def checkQueue(self, ctx, *, name):
+    async def checkQueue(self, ctx):
         await self._pre_load_queues(ctx)
         six_mans_queue = self._get_queue(ctx)
         if six_mans_queue is None:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -477,7 +477,7 @@ class SixMans(commands.Cog):
         self.busy = False
 
     async def _display_game_info(self, ctx, game, six_mans_queue):
-        await game.text_channel.send("{}\n".format(", ".join([player.mention for player in game.players])))
+        await game.textChannel.send("{}\n".format(", ".join([player.mention for player in game.players])))
         embed = discord.Embed(title="{0} 6 Mans Game Info".format(six_mans_queue.name), color=discord.Colour.blue())
         embed.add_field(name="Blue Team", value="{}\n".format(", ".join([player.mention for player in game.blue])), inline=False)
         embed.add_field(name="Orange Team", value="{}\n".format(", ".join([player.mention for player in game.orange])), inline=False)
@@ -492,7 +492,7 @@ class SixMans(commands.Cog):
             "cancel the game.".format(ctx.prefix), inline=False)
         embed.add_field(name="Help", value="If you need any help or have questions please contact an Admin. "
             "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.", inline=False)
-        await game.text_channel.send(embed=embed)
+        await game.textChannel.send(embed=embed)
 
     async def _create_game(self, ctx, six_mans_queue):
         players = [six_mans_queue.queue.get() for _ in range(team_size)]
@@ -509,12 +509,12 @@ class SixMans(commands.Cog):
             },
             category= await self._category(ctx))
         voice_channels = [
-            await guild.create_voice_channel("{0} 6 Mans Blue Team".format(six_mans_queue.name), 
+            await guild.create_voice_channel("{0} Blue Team".format(six_mans_queue.name), 
                 overwrites= {
                     guild.default_role: discord.PermissionOverwrite(connect=False)
                 },
                 category= await self._category(ctx)),
-            await guild.create_voice_channel("{0} 6 Mans Orange Team".format(six_mans_queue.name), 
+            await guild.create_voice_channel("{0} Orange Team".format(six_mans_queue.name), 
                 overwrites= {
                     guild.default_role: discord.PermissionOverwrite(connect=False)
                 },
@@ -524,7 +524,7 @@ class SixMans(commands.Cog):
 
     def _get_game(self, ctx):
         for game in self.games:
-            if game.text_channel == ctx.channel:
+            if game.textChannel == ctx.channel:
                 return game
 
     def _get_queue(self, ctx):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -368,7 +368,7 @@ class SixMans(commands.Cog):
     async def _format_leaderboard(self, ctx, sorted_players, queue_name):
         if queue_name is None:
             queue_name = ctx.guild.name
-        embed = discord.Embed(title="{0} Leaderboard".format(queue_name), color=discord.Colour.blue())
+        embed = discord.Embed(title="{0} 6 Mans Leaderboard".format(queue_name), color=discord.Colour.blue())
         
         index = 1
         message = ""
@@ -417,15 +417,15 @@ class SixMans(commands.Cog):
         game.reset_players()
         game.get_new_captains_from_teams()
 
-        await self._display_game_info(game, six_mans_queue)
+        await self._display_game_info(ctx, game, six_mans_queue)
 
         self.games.append(game)
 
         self.busy = False
 
-    async def _display_game_info(self, game, six_mans_queue):
+    async def _display_game_info(self, ctx, game, six_mans_queue):
         await game.channel.send("{}\n".format(", ".join([player.mention for player in game.players])))
-        embed = discord.Embed(title="{0} Game Info".format(six_mans_queue.name), color=discord.Colour.blue())
+        embed = discord.Embed(title="{0} 6 Mans Game Info".format(six_mans_queue.name), color=discord.Colour.blue())
         embed.add_field(name="Blue Team", value="{}\n".format(", ".join([player.mention for player in game.blue])), inline=False)
         embed.add_field(name="Orange Team", value="{}\n".format(", ".join([player.mention for player in game.orange])), inline=False)
         embed.add_field(name="Captains", value="**Blue:** {0}\n**Orange:** {1}".format(game.captains[0].mention, game.captains[1].mention), inline=False)
@@ -433,11 +433,11 @@ class SixMans(commands.Cog):
         embed.add_field(name="Point Breakdown", value="**Playing:** {0}\n**Winning Bonus:** {1}"
             .format(six_mans_queue.points[pp_play_key], six_mans_queue.points[pp_win_key]), inline=False)
         embed.add_field(name="Additional Info", value="Feel free to play whatever type of series you want, whether a bo3, bo5, or any other.\n\n"
-            "When you are done playing with the current teams please report the winning team using the command `sr [winning_team]` where "
+            "When you are done playing with the current teams please report the winning team using the command `{0}sr [winning_team]` where "
             "the `winning_team` parameter is either `Blue` or `Orange`. Both teams will need to verify the results.\n\nIf you wish to cancel "
-            "the game and allow players to queue again you can use the `cg` command. Both teams will need to verify that they wish to cancel the game.", inline=False)
+            "the game and allow players to queue again you can use the `{0}cg` command. Both teams will need to verify that they wish to cancel the game.", inline=False)
         embed.add_field(name="Help", value="If you need any help or have questions please contact an Admin. "
-            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.", inline=False)
+            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.".format(ctx.prefix), inline=False)
         await game.channel.send(embed=embed)
 
     async def _create_game(self, ctx, six_mans_queue):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -225,6 +225,10 @@ class SixMans(commands.Cog):
             return
 
         game = self._get_game(ctx)
+        if game.scoreReported == True:
+            await ctx.send(":x: Someone has already reported the results or is waiting for verification")
+            return
+
         six_mans_queue = None
         for queue in self.queues:
             if queue.name == game.queueName:
@@ -247,6 +251,7 @@ class SixMans(commands.Cog):
         msg = await ctx.send("{0} Please verify that the **{1}** team won the series".format(opposing_captain.mention, winning_team))
         start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
 
+        game.scoreReported = True
         pred = ReactionPredicate.yes_or_no(msg, opposing_captain)
         await ctx.bot.wait_for("reaction_add", check=pred)
         if pred.result is True:
@@ -254,6 +259,7 @@ class SixMans(commands.Cog):
             pass
         else:
         # User responded with cross
+            game.scoreReported = False
             await ctx.send(":x: Score report not verified. To report the score you will need to use the `sr` command again.")
             return
 
@@ -542,6 +548,7 @@ class Game:
         self.roomPass = self._generate_name_pass()
         self.channel = channel
         self.queueName = queue_name
+        self.scoreReported = False
 
     def add_to_blue(self, player):
         self.players.remove(player)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -558,7 +558,7 @@ class SixMans(commands.Cog):
 
     def _format_queue(self, ctx, queue):
         embed = discord.Embed(title="{0} 6 Mans Queue".format(queue.name), color=discord.Colour.blue())
-        embed.add_field(name="Players in Queue", value="{}\n".format(", ".join([player.mention for player in queue.queue])), inline=False)
+        embed.add_field(name="Players in Queue", value="{}\n".format(", ".join([player.mention for player in queue.queue.queue])), inline=False)
         return embed
 
     async def _pre_load_queues(self, ctx):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -84,10 +84,11 @@ class SixMans(commands.Cog):
             if queue.name == new_name:
                 await ctx.send(":x: There is already a queue set up with the name: {0}".format(new_name))
                 return
-            for channel in queue_channels:
-                if channel in queue.channels:
-                    await ctx.send(":x: {0} is already being used for queue: {1}".format(channel.mention, queue.name))
-                    return
+            if queue.name != current_name:
+                for channel in queue_channels:
+                    if channel in queue.channels:
+                        await ctx.send(":x: {0} is already being used for queue: {1}".format(channel.mention, queue.name))
+                        return
 
         six_mans_queue.name = new_name
         six_mans_queue.points = {pp_play_key: points_per_play, pp_win_key: points_per_win}

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -410,11 +410,14 @@ class SixMans(commands.Cog):
     async def _format_leaderboard(self, ctx, sorted_players, six_mans_queue):
         if six_mans_queue is None:
             queue_name = ctx.guild.name
+            games_played = await self._games_played(ctx)
         else:
             queue_name = six_mans_queue.name
+            games_played = six_mans_queue.gamesPlayed
+        
         embed = discord.Embed(title="{0} 6 Mans Leaderboard".format(queue_name), color=discord.Colour.blue())
-        embed.add_field(name="Games Played", value="{}\n".format(six_mans_queue.gamesPlayed), inline=True)
-        embed.add_field(name="Unique Players All-Time", value="{}\n".format(len(six_mans_queue.players)), inline=True)
+        embed.add_field(name="Games Played", value="{}\n".format(games_played), inline=True)
+        embed.add_field(name="Unique Players All-Time", value="{}\n".format(len(sorted_players), inline=True)
         
         index = 1
         message = ""


### PR DESCRIPTION
Patch Notes:
-Fix issue with double score reporting
-Dynamically create voice channels for each game and delete them after the game score is reported
-Add queue info to leader board and add spacing if member is listed at the bottom not in the top ten
-Add command checkQueue (cq) to show the list of players currently in a queue
-Change minimum game time to 10 minutes instead of 15
-Add admin command to edit queue info
-Edit various bot messages to make things a bit more clear