### PR TITLE
Patch #4 for SixMans cog

### DIFF
--- a/sixMans/data_example.json
+++ b/sixMans/data_example.json
@@ -1,7 +1,23 @@
 {
     "guildId": {
+        "games": {
+            "gameId": {
+                "Players": [],
+                "Captains": [],
+                "Blue": [],
+                "Orange": [],
+                "RoomName": "",
+                "RoomPass": "",
+                "TextChannel": "",
+                "VoiceChannels": [],
+                "QueueId": "",
+                "ScoreReported": ""
+            }
+        },
+
         "queues": {
-            "queue1": {
+            "queue1Id": {
+                "name": "queue1",
                 "channels": ["channel1Id", "channel2Id"],
                 "points": {
                     "play": 1,
@@ -17,7 +33,8 @@
                 "gamesPlayed": 1
             },
     
-            "queue2": {
+            "queue2Id": {
+                "name": "queue2",
                 "channels": ["channel3Id", "channel4Id"],
                 "points": {
                     "play": 2,

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -397,9 +397,14 @@ class SixMans(commands.Cog):
         six_mans_queue = None
         scores = await self._scores(ctx)
 
-        now = datetime.now()
-        then = datetime.strptime(scores[0]["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)")
-        await ctx.send("{0}".format(then))
+        day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        valid_scores = []
+        for score in scores:
+            if datetime.strptime(score["DateTime"]) > day_ago:
+                valid_scores.append(score)
+            else:
+                break
+        await ctx.send("{0}".format(len(valid_scores)))
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -54,7 +54,7 @@ class SixMans(commands.Cog):
     @commands.command()
     @checks.admin_or_permissions(manage_guild=True)
     async def clearSixMansData(self, ctx):
-        msg = await ctx.send("{0} Please verify that you wish to clear all of the 6 Mans data in the sever.".format(ctx.author.mention))
+        msg = await ctx.send("{0} Please verify that you wish to clear all of the 6 Mans data in the server.".format(ctx.author.mention))
         start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
 
         pred = ReactionPredicate.yes_or_no(msg, ctx.author)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -3,6 +3,7 @@ import collections
 import operator
 import random
 import asyncio
+import datetime
 
 from queue import Queue
 from redbot.core import Config
@@ -10,7 +11,6 @@ from redbot.core import commands
 from redbot.core import checks
 from redbot.core.utils.predicates import ReactionPredicate
 from redbot.core.utils.menus import start_adding_reactions
-from datetime import datetime
 
 team_size = 6
 minimum_game_time = 600 #Seconds (10 Minutes)
@@ -397,10 +397,10 @@ class SixMans(commands.Cog):
         six_mans_queue = None
         scores = await self._scores(ctx)
 
-        day_ago = datetime.now() - datetime.timedelta(days=1)
+        day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
         valid_scores = []
         for score in scores:
-            if datetime.strptime(score["DateTime"]) > day_ago:
+            if datetime.datetime.strptime(score["DateTime"]) > day_ago:
                 valid_scores.append(score)
             else:
                 break
@@ -495,7 +495,7 @@ class SixMans(commands.Cog):
         _scores = await self._scores(ctx)
         _players = await self._players(ctx)
         _games_played = await self._games_played(ctx)
-        date_time = datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)")
+        date_time = datetime.datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)")
         for player in winning_players:
             score = self._create_player_score(six_mans_queue, player, 1, date_time)
             self._give_points(six_mans_queue.players, score)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -596,9 +596,9 @@ class SixMans(commands.Cog):
 
     def _swap_opposing_captain(self, game, opposing_captain):
         if opposing_captain in game.blue:
-            game.captains[0] = game.blue[1] #Swap Blue team captain
+            game.captains[0] = list(game.blue)[1] #Swap Blue team captain
         elif opposing_captain in game.orange:
-            game.captains[1] = game.orange[1] #Swap Orange team captain
+            game.captains[1] = list(game.orange)[1] #Swap Orange team captain
 
 
     def _give_points(self, players_dict, score):
@@ -893,7 +893,7 @@ class Game:
     def __init__(self, players, text_channel, voice_channels, queue_id):
         self.id = uuid.uuid4().int
         self.players = set(players)
-        self.captains = list(random.sample(self.players, 2))
+        self.captains = []
         self.blue = set()
         self.orange = set()
         self.roomName = self._generate_name_pass()
@@ -916,9 +916,8 @@ class Game:
         self.players.update(self.blue)
 
     def get_new_captains_from_teams(self):
-        self.captains = []
-        self.captains.append(list(self.blue)[0])
-        self.captains.append(list(self.orange)[0])
+        self.captains.append(random.shuffle(list(self.blue))[0])
+        self.captains.append(random.shuffle(list(self.orange))[0])
 
     def __contains__(self, item):
         return item in self.players or item in self.orange or item in self.blue

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -802,7 +802,7 @@ class SixMans(commands.Cog):
             queues = await self._queues(ctx)
             self.queues = []
             for key, value in queues.items():
-                queue_channels = (ctx.guild.get_channel(x) for x in value["Channels"])
+                queue_channels = [ctx.guild.get_channel(x) for x in value["Channels"]]
                 for queue in self.queues:
                     if queue.name == value["Name"]:
                         await ctx.send(":x: There is already a queue set up with the name: {0}".format(queue.name))
@@ -819,15 +819,15 @@ class SixMans(commands.Cog):
             games = await self._games(ctx)
             game_list = []
             for key, value in games.items():
-                players = (ctx.guild.get_member(x) for x in value["Players"])
+                players = [ctx.guild.get_member(x) for x in value["Players"]]
                 text_channel = ctx.guild.get_channel(value["TextChannel"])
-                voice_channels = (ctx.guild.get_channel(x) for x in value["VoiceChannels"])
+                voice_channels = [ctx.guild.get_channel(x) for x in value["VoiceChannels"]]
                 queueId = value["QueueId"]
                 game = Game(players, text_channel, voice_channels, queueId)
                 game.id = key
-                game.captains = (ctx.guild.get_member(x) for x in value["Captains"])
-                game.blue = set((ctx.guild.get_member(x) for x in value["Blue"]))
-                game.orange = set((ctx.guild.get_member(x) for x in value["Orange"]))
+                game.captains = [ctx.guild.get_member(x) for x in value["Captains"]]
+                game.blue = set([ctx.guild.get_member(x) for x in value["Blue"]])
+                game.orange = set([ctx.guild.get_member(x) for x in value["Orange"]])
                 game.roomName = value["RoomName"]
                 game.roomPass = value["RoomPass"]
                 game.scoreReported = value["ScoreReported"]
@@ -919,14 +919,14 @@ class Game:
 
     def _to_dict(self):
         return {
-            "Players": (x.id for x in self.players),
-            "Captains": (x.id for x in self.captains),
-            "Blue": (x.id for x in self.blue),
-            "Orange": (x.id for x in self.orange),
+            "Players": [x.id for x in self.players],
+            "Captains": [x.id for x in self.captains],
+            "Blue": [x.id for x in self.blue],
+            "Orange": [x.id for x in self.orange],
             "RoomName": self.roomName,
             "RoomPass": self.roomPass,
             "TextChannel": self.textChannel.id,
-            "VoiceChannels": (x.id for x in self.voiceChannels),
+            "VoiceChannels": [x.id for x in self.voiceChannels],
             "QueueId": self.queueId,
             "ScoreReported": self.scoreReported,
         }
@@ -1070,7 +1070,7 @@ class SixMansQueue:
     def _to_dict(self):
         return {
             "Name": self.name,
-            "Channels": (x.id for x in self.channels),
+            "Channels": [x.id for x in self.channels],
             "Points": self.points,
             "Players": self.players,
             "GamesPlayed": self.gamesPlayed

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -916,10 +916,9 @@ class Game:
         self.players.update(self.blue)
 
     def get_new_captains_from_teams(self):
-        random.shuffle(self.blue)
-        random.shuffle(self.orange)
-        self.captains.append(list(self.blue)[0])
-        self.captains.append(list(self.orange)[0])
+        self.captains = []
+        self.captains.append(random.sample(list(self.blue), 1))
+        self.captains.append(random.sample(list(self.orange), 1))
 
     def __contains__(self, item):
         return item in self.players or item in self.orange or item in self.blue

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -696,6 +696,7 @@ class SixMans(commands.Cog):
 
     def _format_rank(self, ctx, player, sorted_players, queue_name, rnk_format):
         try:
+            num_players = len(sorted_players)
             points_index = [y[0] for y in sorted_players].index("{0}".format(player.id))
             player_info = sorted_players[points_index][1]
             points, wins, games_played = player_info[player_points_key], player_info[player_wins_key], player_info[player_gp_key]
@@ -703,9 +704,9 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(points_index, points), inline=True)
-            embed.add_field(name="Wins:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(wins_index, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(games_played_index, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Rank:** {0}/{1} **Total:** {2}".format(points_index, num_players, points), inline=True)
+            embed.add_field(name="Wins:", value="**Rank:** {0}/{1} **Total:** {2}".format(wins_index, num_players, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Rank:** {0}/{1} **Total:** {2}".format(games_played_index, num_players, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank {}".format(player.mention))

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -23,7 +23,7 @@ player_gp_key = "GamesPlayed"
 player_wins_key = "Wins"
 queues_key = "Queues"
 
-defaults = {"CategoryChannel": None, "HelperRole": None, "Queues": {}, "GamesPlayed": 0, "Players": {}, "Scores": []}
+defaults = {"CategoryChannel": None, "HelperRole": None, "Games": {}, "Queues": {}, "GamesPlayed": 0, "Players": {}, "Scores": []}
 
 class SixMans(commands.Cog):
 
@@ -828,7 +828,7 @@ class SixMans(commands.Cog):
             self.games = game_list
 
     async def _games(self, ctx):
-        return await self.config.guild(ctx.guild).Queues()
+        return await self.config.guild(ctx.guild).Games()
 
     async  def _save_games(self, ctx, games):
         game_dict = {}
@@ -837,7 +837,7 @@ class SixMans(commands.Cog):
         await self.config.guild(ctx.guild).Games.set(game_dict)
 
     async def _queues(self, ctx):
-        return await self.config.guild(ctx.guild).Games()
+        return await self.config.guild(ctx.guild).Queues()
 
     async  def _save_queues(self, ctx, queues):
         queue_dict = {}

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -39,15 +39,31 @@ class SixMans(commands.Cog):
     @checks.admin_or_permissions(manage_guild=True)
     async def loadGames(self, ctx):
         await self._pre_load_queues(ctx)
-        await self._pre_load_games(ctx, True)
-        await ctx.send("Done")
+        msg = await ctx.send("{0} Please verify that you wish to reload the games.".format(ctx.author.mention))
+        start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
+
+        pred = ReactionPredicate.yes_or_no(msg, ctx.author)
+        await ctx.bot.wait_for("reaction_add", check=pred)
+        if pred.result is True:
+            await self._pre_load_games(ctx, True)
+            await ctx.send("Done")
+        else:
+            await ctx.send(":x: Games **not** reloaded.".format(ctx.prefix))
 
     @commands.guild_only()
     @commands.command()
     @checks.admin_or_permissions(manage_guild=True)
     async def clearSixMansData(self, ctx):
-        await self.config.clear_all_guilds()
-        await ctx.send("Done")
+        msg = await ctx.send("{0} Please verify that you wish to clear all of the 6 Mans data in the sever.".format(ctx.author.mention))
+        start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
+
+        pred = ReactionPredicate.yes_or_no(msg, ctx.author)
+        await ctx.bot.wait_for("reaction_add", check=pred)
+        if pred.result is True:
+            await self.config.clear_all_guilds()
+            await ctx.send("Done")
+        else:
+            await ctx.send(":x: Data **not** cleared.".format(ctx.prefix))
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -916,8 +916,10 @@ class Game:
         self.players.update(self.blue)
 
     def get_new_captains_from_teams(self):
-        self.captains.append(random.shuffle(list(self.blue))[0])
-        self.captains.append(random.shuffle(list(self.orange))[0])
+        random.shuffle(self.blue)
+        random.shuffle(self.orange)
+        self.captains.append(list(self.blue)[0])
+        self.captains.append(list(self.orange)[0])
 
     def __contains__(self, item):
         return item in self.players or item in self.orange or item in self.blue

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -358,7 +358,7 @@ class SixMans(commands.Cog):
         await self._finish_game(ctx, game, six_mans_queue, winning_team)
 
     @commands.guild_only()
-    @commands.command(aliases=["qlb"])
+    @commands.group(aliases=["qlb"])
     async def queueLeaderBoard(self, ctx, *, queue_name: str = None):
         """Get the top ten players in points for the specific queue. If no queue name is given the list will be the top ten players across all queues.
         If you're not in the top ten your name and rank will be shown at the bottom of the list."""
@@ -382,6 +382,11 @@ class SixMans(commands.Cog):
         sorted_players = sorted(players.items(), key=lambda x: x[1][player_wins_key], reverse=True)
         sorted_players = sorted(sorted_players, key=lambda x: x[1][player_points_key], reverse=True)
         await ctx.send(embed=await self._format_leaderboard(ctx, sorted_players, queue_name, games_played))
+
+    @commands.guild_only()
+    @queueLeaderBoard.command(aliases=["month"])
+    async def monthly(self, ctx, *, queue_name: str = None):
+        await ctx.send("Test passed")
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -704,9 +704,9 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Rank:** {0}/{1} **Total:** {2}".format(points_index, num_players, points), inline=True)
-            embed.add_field(name="Wins:", value="**Rank:** {0}/{1} **Total:** {2}".format(wins_index, num_players, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Rank:** {0}/{1} **Total:** {2}".format(games_played_index, num_players, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Value:** {2} **Rank:** {0}/{1}".format(points_index, num_players, points), inline=True)
+            embed.add_field(name="Wins:", value="**Value:** {2} **Rank:** {0}/{1}".format(wins_index, num_players, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Value:** {2} **Rank:** {0}/{1}".format(games_played_index, num_players, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank {}".format(player.mention))

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -463,7 +463,7 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @commands.group(aliases=["rnk"])
     async def rank(self, ctx):
-        """Get your rank in points for the specific queue. If no queue name is given it will show your overall rank across all queues."""
+        """Get your rank in points, wins, and games played for the specific queue. If no queue name is given it will show your overall rank across all queues."""
 
     @commands.guild_only()
     @rank.command(aliases=["all-time", "overall"])
@@ -762,9 +762,9 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Value:** {2} **Rank:** {0}/{1}".format(points_index, num_players, points), inline=True)
-            embed.add_field(name="Wins:", value="**Value:** {2} **Rank:** {0}/{1}".format(wins_index, num_players, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Value:** {2} **Rank:** {0}/{1}".format(games_played_index, num_players, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Value:** {2} **Rank:** {0}/{1}".format(points_index + 1, num_players, points), inline=True)
+            embed.add_field(name="Wins:", value="**Value:** {2} **Rank:** {0}/{1}".format(wins_index + 1, num_players, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Value:** {2} **Rank:** {0}/{1}".format(games_played_index + 1, num_players, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank {}".format(player.mention))

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -917,8 +917,8 @@ class Game:
 
     def get_new_captains_from_teams(self):
         self.captains = []
-        self.captains.append(random.sample(list(self.blue), 1))
-        self.captains.append(random.sample(list(self.orange), 1))
+        self.captains.append(random.sample(list(self.blue), 1)[0])
+        self.captains.append(random.sample(list(self.orange), 1)[0])
 
     def __contains__(self, item):
         return item in self.players or item in self.orange or item in self.blue

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -701,13 +701,15 @@ class SixMans(commands.Cog):
             points, wins, games_played = player_info[player_points_key], player_info[player_wins_key], player_info[player_gp_key]
             wins_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_points_key], reverse=True)].index("{0}".format(player.id))
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
-            embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue(), thumbnail=player.avatar_url)
+            embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
+            embed.add_thumbnail(url=player.avatar_url)
             embed.add_field(name="Points:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(points_index, points), inline=True)
             embed.add_field(name="Wins:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(wins_index, wins), inline=True)
             embed.add_field(name="Games Played:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(games_played_index, games_played), inline=True)
         except:
-            embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(), thumbnail=player.avatar_url,
+            embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank you")
+            embed.add_thumbnail(url=player.avatar_url)
         return embed
 
     async def _randomize_teams(self, ctx, six_mans_queue):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -485,7 +485,7 @@ class SixMans(commands.Cog):
 
         sorted_players = self._sort_player_dict(players)
         player = player if player else ctx.author
-        await ctx.send(embed=await self._format_rank(ctx, player, sorted_players, queue_name, "All-time"))
+        await ctx.send(embed=self._format_rank(ctx, player, sorted_players, queue_name, "All-time"))
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -38,6 +38,7 @@ class SixMans(commands.Cog):
     @commands.command()
     @checks.admin_or_permissions(manage_guild=True)
     async def loadGames(self, ctx):
+        await self._pre_load_queues(ctx)
         await self._pre_load_games(ctx, True)
         await ctx.send("Done")
 
@@ -803,8 +804,9 @@ class SixMans(commands.Cog):
             self.queues = []
             for key, value in queues.items():
                 queue_channels = [ctx.guild.get_channel(x) for x in value["Channels"]]
+                queue_name = value["Name"]
                 for queue in self.queues:
-                    if queue.name == value["Name"]:
+                    if queue.name == queue_name:
                         await ctx.send(":x: There is already a queue set up with the name: {0}".format(queue.name))
                         return
                     for channel in queue_channels:
@@ -812,7 +814,9 @@ class SixMans(commands.Cog):
                             await ctx.send(":x: {0} is already being used for queue: {1}".format(channel.mention, queue.name))
                             return
 
-                self.queues.append(SixMansQueue(key, queue_channels, value["Points"], value["Players"], value["GamesPlayed"]))
+                six_mans_queue = SixMansQueue(queue_name, queue_channels, value["Points"], value["Players"], value["GamesPlayed"])
+                six_mans_queue.id = key
+                self.queues.append(six_mans_queue)
 
     async def _pre_load_games(self, ctx, force_load):
         if self.games is None or self.games == [] or force_load:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -398,7 +398,7 @@ class SixMans(commands.Cog):
         scores = await self._scores(ctx)
 
         now = datetime.now()
-        then = datetime.strftime(scores[0]["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)")
+        then = datetime.strptime(scores[0]["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)")
         await ctx.send("{0}".format(then))
 
     @commands.guild_only()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -703,12 +703,12 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(points_index, points), inline=True)
-            embed.add_field(name="Wins:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(wins_index, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(games_played_index, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Rank:** {0}      **Total:** {1}".format(points_index, points), inline=True)
+            embed.add_field(name="Wins:", value="**Rank:** {0}      **Total:** {1}".format(wins_index, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Rank:** {0}      **Total:** {1}".format(games_played_index, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
-                description="No stats yet to rank you")
+                description="No stats yet to rank {}".format(player.mention))
             embed.set_thumbnail(url=player.avatar_url)
         return embed
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -364,8 +364,8 @@ class SixMans(commands.Cog):
         If you're not in the top ten your name and rank will be shown at the bottom of the list."""
 
     @commands.guild_only()
-    @queueLeaderBoard.command(aliases=["all-time", "alltime"])
-    async def overall(self, ctx, *, queue_name: str = None):
+    @queueLeaderBoard.command(aliases=["all-time", "overall"])
+    async def alltime(self, ctx, *, queue_name: str = None):
         """All-Time leader board"""
         await self._pre_load_queues(ctx)
         players = None
@@ -397,7 +397,7 @@ class SixMans(commands.Cog):
         six_mans_queue = None
         scores = await self._scores(ctx)
 
-        day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        day_ago = datetime.now() - datetime.timedelta(days=1)
         valid_scores = []
         for score in scores:
             if datetime.strptime(score["DateTime"]) > day_ago:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -400,7 +400,7 @@ class SixMans(commands.Cog):
         day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
         valid_scores = []
         for score in scores:
-            if datetime.datetime.strptime(score["DateTime"]) > day_ago:
+            if datetime.datetime.strptime(score["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)") > day_ago:
                 valid_scores.append(score)
             else:
                 break

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -703,9 +703,9 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Rank:** {0}      **Total:** {1}".format(points_index, points), inline=True)
-            embed.add_field(name="Wins:", value="**Rank:** {0}      **Total:** {1}".format(wins_index, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Rank:** {0}      **Total:** {1}".format(games_played_index, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(points_index, points), inline=True)
+            embed.add_field(name="Wins:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(wins_index, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Rank:** {0}_ __ __ _**Total:** {1}".format(games_played_index, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank {}".format(player.mention))

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -702,14 +702,14 @@ class SixMans(commands.Cog):
             wins_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_points_key], reverse=True)].index("{0}".format(player.id))
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
-            embed.add_thumbnail(url=player.avatar_url)
+            embed.set_thumbnail(url=player.avatar_url)
             embed.add_field(name="Points:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(points_index, points), inline=True)
             embed.add_field(name="Wins:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(wins_index, wins), inline=True)
             embed.add_field(name="Games Played:", value="**Rank:** {0}\t\t\t**Total:** {1}".format(games_played_index, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank you")
-            embed.add_thumbnail(url=player.avatar_url)
+            embed.set_thumbnail(url=player.avatar_url)
         return embed
 
     async def _randomize_teams(self, ctx, six_mans_queue):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -373,6 +373,7 @@ class SixMans(commands.Cog):
         if queue_name is not None:
             for queue in self.queues:
                 if queue.name.lower() == queue_name.lower():
+                    queue_name = queue.name
                     players = queue.players
                     games_played = six_mans_queue.gamesPlayed
         else:
@@ -411,6 +412,10 @@ class SixMans(commands.Cog):
 
         if queue_name is None:
             queue_name = ctx.guild.name
+        else:
+            for queue in self.queues:
+                if queue.name.lower() == queue_name.lower():
+                    queue_name = queue.name
 
         games_played = valid_scores // 6
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -447,7 +447,7 @@ class SixMans(commands.Cog):
 
     async def _remove_from_queue(self, player, six_mans_queue):
         six_mans_queue.queue.remove(player)
-        player_list = "{}".format(", ".join([player.mention for player in queue.queue.queue]))
+        player_list = "{}".format(", ".join([player.mention for player in six_mans_queue.queue.queue]))
         if player_list == "":
             player_list = "No players currently in the queue"
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -674,9 +674,9 @@ class SixMans(commands.Cog):
 
     def _swap_opposing_captain(self, game, opposing_captain):
         if opposing_captain in game.blue:
-            game.captains[0] = list(game.blue)[1] #Swap Blue team captain
+            game.captains[0] = random.sample(list(game.blue), 1)[0] #Swap Blue team captain
         elif opposing_captain in game.orange:
-            game.captains[1] = list(game.orange)[1] #Swap Orange team captain
+            game.captains[1] = random.sample(list(game.orange), 1)[0] #Swap Orange team captain
 
 
     def _give_points(self, players_dict, score):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -39,6 +39,14 @@ class SixMans(commands.Cog):
     @checks.admin_or_permissions(manage_guild=True)
     async def loadGames(self, ctx):
         await self._pre_load_games(ctx, True)
+        await ctx.send("Done")
+
+    @commands.guild_only()
+    @commands.command()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def clearSixMansData(self, ctx):
+        await self.config.clear_all_guilds()
+        await ctx.send("Done")
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -762,9 +762,9 @@ class SixMans(commands.Cog):
             games_played_index = [y[0] for y in sorted(sorted_players, key=lambda x: x[1][player_gp_key], reverse=True)].index("{0}".format(player.id))
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.blue())
             embed.set_thumbnail(url=player.avatar_url)
-            embed.add_field(name="Points:", value="**Value:** {2} **Rank:** {0}/{1}".format(points_index + 1, num_players, points), inline=True)
-            embed.add_field(name="Wins:", value="**Value:** {2} **Rank:** {0}/{1}".format(wins_index + 1, num_players, wins), inline=True)
-            embed.add_field(name="Games Played:", value="**Value:** {2} **Rank:** {0}/{1}".format(games_played_index + 1, num_players, games_played), inline=True)
+            embed.add_field(name="Points:", value="**Value:** {2} | **Rank:** {0}/{1}".format(points_index + 1, num_players, points), inline=True)
+            embed.add_field(name="Wins:", value="**Value:** {2} | **Rank:** {0}/{1}".format(wins_index + 1, num_players, wins), inline=True)
+            embed.add_field(name="Games Played:", value="**Value:** {2} | **Rank:** {0}/{1}".format(games_played_index + 1, num_players, games_played), inline=True)
         except:
             embed = discord.Embed(title="{0} {1} 6 Mans {2} Rank".format(player.display_name, queue_name, rnk_format), color=discord.Colour.red(),
                 description="No stats yet to rank {}".format(player.mention))
@@ -813,8 +813,9 @@ class SixMans(commands.Cog):
             "the `winning_team` parameter is either `Blue` or `Orange`. Both teams will need to verify the results.\n\nIf you wish to cancel "
             "the game and allow players to queue again you can use the `{0}cg` command. Both teams will need to verify that they wish to "
             "cancel the game.".format(ctx.prefix), inline=False)
-        embed.add_field(name="Help", value="If you need any help or have questions please contact an Admin. "
-            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.", inline=False)
+        embed.add_field(name="Help", value="If you need any help or have questions please contact someone with the {} role. "
+            "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast.".format((await self._helper_role(ctx)).mention),
+            inline=False)
         await game.textChannel.send(embed=embed)
 
     async def _create_game(self, ctx, six_mans_queue):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -415,7 +415,7 @@ class SixMans(commands.Cog):
         await self._pre_load_queues(ctx)
         scores = await self._scores(ctx)
 
-        week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+        week_ago = datetime.datetime.now() - datetime.timedelta(weeks=1)
         players, games_played = self._filter_scores(scores, week_ago, queue_name)
 
         if players is None or players == {}:
@@ -435,7 +435,7 @@ class SixMans(commands.Cog):
         await self._pre_load_queues(ctx)
         scores = await self._scores(ctx)
 
-        month_ago = datetime.datetime.now() - datetime.timedelta(months=1)
+        month_ago = datetime.datetime.now() - datetime.timedelta(days=30.4)
         players, games_played = self._filter_scores(scores, month_ago, queue_name)
 
         if players is None or players == {}:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -406,7 +406,7 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @queueLeaderBoard.command(aliases=["day"])
     async def daily(self, ctx, *, queue_name: str = None):
-        """Daily leader board. All scores from the last 24 hours will count"""
+        """Daily leader board. All games from the last 24 hours will count"""
         await self._pre_load_queues(ctx)
         scores = await self._scores(ctx)
 
@@ -423,9 +423,9 @@ class SixMans(commands.Cog):
         await ctx.send(embed=await self._format_leaderboard(ctx, sorted_players, queue_name, games_played, "Daily"))
 
     @commands.guild_only()
-    @queueLeaderBoard.command(aliases=["week"])
+    @queueLeaderBoard.command(aliases=["week", "wk"])
     async def weekly(self, ctx, *, queue_name: str = None):
-        """Weekly leader board. All scores from the last week will count"""
+        """Weekly leader board. All games from the last week will count"""
         await self._pre_load_queues(ctx)
         scores = await self._scores(ctx)
 
@@ -442,9 +442,9 @@ class SixMans(commands.Cog):
         await ctx.send(embed=await self._format_leaderboard(ctx, sorted_players, queue_name, games_played, "Weekly"))
 
     @commands.guild_only()
-    @queueLeaderBoard.command(aliases=["month"])
+    @queueLeaderBoard.command(aliases=["month", "mnth"])
     async def monthly(self, ctx, *, queue_name: str = None):
-        """Monthly leader board. All scores from the last 30 days will count"""
+        """Monthly leader board. All games from the last 30 days will count"""
         await self._pre_load_queues(ctx)
         scores = await self._scores(ctx)
 
@@ -468,6 +468,7 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @rank.command(aliases=["all-time", "overall"])
     async def alltime(self, ctx, player: discord.Member = None, *, queue_name: str = None):
+        """All-time ranks"""
         await self._pre_load_queues(ctx)
         players = None
         if queue_name is not None:
@@ -486,6 +487,63 @@ class SixMans(commands.Cog):
         sorted_players = self._sort_player_dict(players)
         player = player if player else ctx.author
         await ctx.send(embed=self._format_rank(ctx, player, sorted_players, queue_name, "All-time"))
+
+    @commands.guild_only()
+    @rank.command(aliases=["day"])
+    async def daily(self, ctx, player: discord.Member = None, *, queue_name: str = None):
+        """Daily ranks. All games from the last 24 hours will count"""
+        await self._pre_load_queues(ctx)
+        scores = await self._scores(ctx)
+
+        queue_id = self._get_queue_id_by_name(queue_name)
+        day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
+        players, games_played = self._filter_scores(scores, day_ago, queue_id)
+
+        if players is None or players == {}:
+            await ctx.send(":x: Queue leaderboard not available for {0}".format(queue_name))
+            return
+
+        sorted_players = self._sort_player_dict(players)
+        player = player if player else ctx.author
+        await ctx.send(embed=self._format_rank(ctx, player, sorted_players, queue_name, "Daily"))
+
+    @commands.guild_only()
+    @rank.command(aliases=["week", "wk"])
+    async def weekly(self, ctx, player: discord.Member = None, *, queue_name: str = None):
+        """Weekly ranks. All games from the last week will count"""
+        await self._pre_load_queues(ctx)
+        scores = await self._scores(ctx)
+
+        queue_id = self._get_queue_id_by_name(queue_name)
+        week_ago = datetime.datetime.now() - datetime.timedelta(weeks=1)
+        players, games_played = self._filter_scores(scores, week_ago, queue_id)
+
+        if players is None or players == {}:
+            await ctx.send(":x: Queue leaderboard not available for {0}".format(queue_name))
+            return
+
+        sorted_players = self._sort_player_dict(players)
+        player = player if player else ctx.author
+        await ctx.send(embed=self._format_rank(ctx, player, sorted_players, queue_name, "Weekly"))
+
+    @commands.guild_only()
+    @rank.command(aliases=["month", "mnth"])
+    async def monthly(self, ctx, player: discord.Member = None, *, queue_name: str = None):
+        """Monthly ranks. All games from the last 30 days will count"""
+        await self._pre_load_queues(ctx)
+        scores = await self._scores(ctx)
+
+        queue_id = self._get_queue_id_by_name(queue_name)
+        month_ago = datetime.datetime.now() - datetime.timedelta(days=30)
+        players, games_played = self._filter_scores(scores, month_ago, queue_id)
+
+        if players is None or players == {}:
+            await ctx.send(":x: Queue leaderboard not available for {0}".format(queue_name))
+            return
+
+        sorted_players = self._sort_player_dict(players)
+        player = player if player else ctx.author
+        await ctx.send(embed=self._format_rank(ctx, player, sorted_players, queue_name, "Monthly"))
 
     @commands.guild_only()
     @commands.command()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -286,6 +286,8 @@ class SixMans(commands.Cog):
                 six_mans_queue = queue
 
         if six_mans_queue is None:
+            await ctx.send("{0}, {1}".format(queue.id, game.queueId))
+            await ctx.send(queue.id + game.queueId)
             await ctx.send(":x: Queue not found for this channel, please message an Admin if you think this is a mistake.")
             return
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -817,7 +817,7 @@ class SixMans(commands.Cog):
                             return
 
                 six_mans_queue = SixMansQueue(queue_name, queue_channels, value["Points"], value["Players"], value["GamesPlayed"])
-                six_mans_queue.id = key
+                six_mans_queue.id = int(key)
                 self.queues.append(six_mans_queue)
 
     async def _pre_load_games(self, ctx, force_load):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -366,6 +366,7 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @queueLeaderBoard.command(aliases=["all-time", "alltime"])
     async def overall(self, ctx, *, queue_name: str = None):
+        """All-Time leader board"""
         await self._pre_load_queues(ctx)
         players = None
         six_mans_queue = None
@@ -390,10 +391,11 @@ class SixMans(commands.Cog):
     @commands.guild_only()
     @queueLeaderBoard.command(aliases=["day"])
     async def daily(self, ctx, *, queue_name: str = None):
+        """Daily leader board. All scores from the last 24 hours will count"""
         await self._pre_load_queues(ctx)
         players = None
         six_mans_queue = None
-        scores = self._scores(ctx)
+        scores = await self._scores(ctx)
 
         now = datetime.now()
         then = datetime.strftime(scores[0]["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)")

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -437,9 +437,9 @@ class SixMans(commands.Cog):
         six_mans_queue.queue.put(player)
         player_list = "{}".format(", ".join([player.mention for player in six_mans_queue.queue.queue]))
 
-        embed = discord.Embed(title="{0} added to {1} queue. ({2}/{3})".format(player.mention, six_mans_queue.name,
-            six_mans_queue.queue.qsize(), team_size), color=discord.Colour.green())
-        embed.set_author(name="{}".format(player.display_name), icon_url="{}".format(player.avatar_url))
+        embed = discord.Embed(color=discord.Colour.green())
+        embed.set_author(name="{0} added to the {1} queue. ({2}/{3})".format(player.display_name, six_mans_queue.name,
+            six_mans_queue.queue.qsize(), team_size), icon_url="{}".format(player.avatar_url))
         embed.add_field(name="Players in Queue", value=player_list, inline=False)
 
         for channel in six_mans_queue.channels:
@@ -451,9 +451,9 @@ class SixMans(commands.Cog):
         if player_list == "":
             player_list = "No players currently in the queue"
 
-        embed = discord.Embed(title="{0} removed from the {1} queue. ({2}/{3})".format(player.mention, six_mans_queue.name,
-            six_mans_queue.queue.qsize(), team_size), color=discord.Colour.red())
-        embed.set_author(name="{}".format(player.display_name), icon_url="{}".format(player.avatar_url))
+        embed = discord.Embed(color=discord.Colour.red())
+        embed.set_author(name="{0} removed from the {1} queue. ({2}/{3})".format(player.display_name, six_mans_queue.name,
+            six_mans_queue.queue.qsize(), team_size), icon_url="{}".format(player.avatar_url))
         embed.add_field(name="Players in Queue", value=player_list, inline=False)
 
         for channel in six_mans_queue.channels:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -2,7 +2,6 @@ import discord
 import collections
 import operator
 import random
-import datetime
 import asyncio
 
 from queue import Queue
@@ -11,6 +10,7 @@ from redbot.core import commands
 from redbot.core import checks
 from redbot.core.utils.predicates import ReactionPredicate
 from redbot.core.utils.menus import start_adding_reactions
+from datetime import datetime
 
 team_size = 6
 minimum_game_time = 600 #Seconds (10 Minutes)
@@ -359,9 +359,13 @@ class SixMans(commands.Cog):
 
     @commands.guild_only()
     @commands.group(aliases=["qlb"])
-    async def queueLeaderBoard(self, ctx, *, queue_name: str = None):
+    async def queueLeaderBoard(self, ctx):
         """Get the top ten players in points for the specific queue. If no queue name is given the list will be the top ten players across all queues.
         If you're not in the top ten your name and rank will be shown at the bottom of the list."""
+
+    @commands.guild_only()
+    @queueLeaderBoard.command(aliases=["all-time", "alltime"])
+    async def overall(self, ctx, *, queue_name: str = None):
         await self._pre_load_queues(ctx)
         players = None
         six_mans_queue = None
@@ -384,9 +388,16 @@ class SixMans(commands.Cog):
         await ctx.send(embed=await self._format_leaderboard(ctx, sorted_players, queue_name, games_played))
 
     @commands.guild_only()
-    @queueLeaderBoard.command(aliases=["month"])
-    async def monthly(self, ctx, *, queue_name: str = None):
-        await ctx.send("Test passed")
+    @queueLeaderBoard.command(aliases=["day"])
+    async def daily(self, ctx, *, queue_name: str = None):
+        await self._pre_load_queues(ctx)
+        players = None
+        six_mans_queue = None
+        scores = self._scores(ctx)
+
+        now = datetime.now()
+        then = datetime.strftime(scores[0]["DateTime"], "%d-%b-%Y (%H:%M:%S.%f)")
+        await ctx.send("{0}".format(then))
 
     @commands.guild_only()
     @commands.command()
@@ -477,7 +488,7 @@ class SixMans(commands.Cog):
         _scores = await self._scores(ctx)
         _players = await self._players(ctx)
         _games_played = await self._games_played(ctx)
-        date_time = datetime.datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)")
+        date_time = datetime.now().strftime("%d-%b-%Y (%H:%M:%S.%f)")
         for player in winning_players:
             score = self._create_player_score(six_mans_queue, player, 1, date_time)
             self._give_points(six_mans_queue.players, score)


### PR DESCRIPTION
Patch Notes:
-Add Daily, Weekly, and Monthly leaderboards
     -Can be accessed using `[p]qlb daily`, `[p]qlb weekly`, `[p]qlb monthly`
-Add `[p]rank` command to find All-time, Daily, Weekly, or Monthly ranks for you or any other member
-Improve randomness of captains
-Improve messages for joining/leaving the queue
-Use ids to better keep track of queues and games