### PR TITLE
simplify franchise creation/deletion, automate role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For any command, you can see documentation explaining how to use the command wit
 
 #### Franchises/Prefixes
 
-As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. Alternatively, the command `<p>addFranchise` to complete all of these steps for adding a single team simultaneously.
+As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. Alternatively, the command `<p>addFranchise` to complete all necessary steps for adding a single franchise simultaneously.
 
 #### Tiers
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,21 @@ Certain cogs depend on another cog being loaded first in order to work correctly
 
 Many of the RSC league specific cogs rely on roles being set up in the Discord server a certain way or data, such as team names and prefixes, to be added to the bot before they can be used. In this section I'll attempt to explain all the steps required in setting up the league specifics cogs correctly.
 
-#### Prefixes
+#### Commands
 
-As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. You can use `<p>help addPrefix` and `<p>help addPrefixes` in Discord to see documentation explaining how to use each command.
+For any command, you can use the command `<p>help <command name>` to see documentation explaining how to use the command.
+
+#### Franchises/Prefixes
+
+As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. Alternatively, the command `<p>addFranchise` to complete all of these steps simultaneously.
 
 #### Tiers
 
-Tiers are added through the teamManager cog using the `<p>addTier` command. The bot will accept any name for the tier, but you'll also want a role in the Discord server with the same name as the tier. This tier role, along with the franchise roles, will be used to help determine what team a player is currently on. For each tier, you'll also want a corresponding free agent role. For example, for a tier named `Premier` you'll want to have a tier role also named `Premier` and a free agent role named `PremierFA`.
+Tiers are added through the teamManager cog using the `<p>addTier` command. The bot will accept any name for the tier. This will create a role for the tier, which along with the franchise roles, will be used to help determine what team a player is currently on. For each tier added, a corresponding free agent role will also be generated. For example, for a tier named `Premier` the role `Premier` and a free agent role named `PremierFA` will be generated.
 
 #### Teams
 
-For RSC, each team will need to have a team name, a corresponding GM (General Manager), and a tier that the team plays in. For each GM, there must be a corresponding franchise role that follows the naming format given in the Prefixes subsection above. Each tier should already be loaded into the bot according to the Tiers subsection above. Teams need to be added to the bot in order to use commands such as `<p>match`, `<p>roster`, or any of the transaction commands. Most of the commands involving teams are in the teamManager cog. To add a team to the bot the `<p>addTeam` command can be used to add them one at a time, or the `<p>addTeams` command can be used to add them in bulk. You can use `<p>help addTeam` and `<p>help addTeams` in Discord to see documentation explaining how to use each command.
+For RSC, each team will need to have a team name, a corresponding GM (General Manager), and a tier that the team plays in (which are generated from previous commands). Each tier should already be loaded into the bot according to the Tiers subsection above. Teams need to be added to the bot in order to use commands such as `<p>match`, `<p>roster`, or any of the transaction commands. Most of the commands involving teams are in the teamManager cog. To add a team to the bot the `<p>addTeam` command can be used to add them one at a time, or the `<p>addTeams` command can be used to add them in bulk. When a team is added to a franchise, the GM is given the tier role to reflect the addition of the team at that tier.
 
 #### Matches
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For any command, you can use the command `<p>help <command name>` to see documen
 
 #### Franchises/Prefixes
 
-As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. Alternatively, the command `<p>addFranchise` to complete all of these steps simultaneously.
+As can be seen in the [cog dependencies doc](https://docs.google.com/drawings/d/1Ys3Ne_66uTECXY47WTLPr3LlWi_XL8rUGf2S90jY7Nk/edit?usp=sharing), the prefixManager cog should be the first cog loaded from the league specific cogs. For RSC, a prefix should be added for each franchise within the league. To add a prefix you first need to set up a franchise role with the following name format: [<franchise_name> (<GM_name>)](https://media.discordapp.net/attachments/679698891129880580/707975741505273938/Capture.PNG). After that the `<p>addPrefix` command can be used to add prefixes one at a time, or the `<p>addPrefixes` command can be used to add them in bulk. Alternatively, the command `<p>addFranchise` to complete all of these steps for adding a single team simultaneously.
 
 #### Tiers
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Many of the RSC league specific cogs rely on roles being set up in the Discord s
 
 #### Commands
 
-For any command, you can use the command `<p>help <command name>` to see documentation explaining how to use the command.
+For any command, you can see documentation explaining how to use the command with the format: `<p>help <command name>`
 
 #### Franchises/Prefixes
 

--- a/prefixManager/prefixManager.py
+++ b/prefixManager/prefixManager.py
@@ -77,14 +77,11 @@ class PrefixManager(commands.Cog):
     @checks.admin_or_permissions(manage_guild=True)
     async def removePrefix(self, ctx, gm_name: str):
         """Remove a single prefix. The GM will no longer have a prefix in the dictionary"""
-        prefixes = await self._prefixes(ctx)
-        try:
-            del prefixes[gm_name]
-        except ValueError:
-            await ctx.send("{0} does not have a prefix.".format(gm_name))
-            return
-        await self._save_prefixes(ctx, prefixes)
-        await ctx.send("Done.")
+        prefixRemoved = await self.remove_prefix(ctx, gm_name)
+        if(prefixRemoved):
+            await ctx.send("Done.")
+        else:
+            await ctx.send("Error removing prefix for {0}".format(gm_name))
 
     @commands.command()
     @commands.guild_only()
@@ -171,6 +168,16 @@ class PrefixManager(commands.Cog):
             prefixes[proper_gm_name] = prefix
         except:
             return False
+        await self._save_prefixes(ctx, prefixes)
+        return True
+
+    async def remove_prefix(self, ctx, gm_name: str):
+        prefixes = await self._prefixes(ctx)
+        try:
+            del prefixes[gm_name]
+        except ValueError:
+            await ctx.send("{0} does not have a prefix.".format(gm_name))
+            return
         await self._save_prefixes(ctx, prefixes)
         return True
 

--- a/prefixManager/prefixManager.py
+++ b/prefixManager/prefixManager.py
@@ -51,7 +51,7 @@ class PrefixManager(commands.Cog):
     @checks.admin_or_permissions(manage_guild=True)
     async def addPrefix(self, ctx, gm_name: str, prefix: str):
         """Add a single prefix and corresponding GM name."""
-        prefixAdded = await self._add_prefix(ctx, gm_name, prefix)
+        prefixAdded = await self.add_prefix(ctx, gm_name, prefix)
         if(prefixAdded):
             await ctx.send("Done.")
         else:
@@ -149,7 +149,7 @@ class PrefixManager(commands.Cog):
             message += ". {0} user(s) had their nickname removed".format(removed)
         await ctx.send(message)
 
-    async def _add_prefix(self, ctx, gm_name: str, prefix: str):
+    async def add_prefix(self, ctx, gm_name: str, prefix: str):
         prefixes = await self._prefixes(ctx)
 
         proper_gm_name = self._get_proper_gm_name(ctx, gm_name)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -48,8 +48,8 @@ class TeamManager(commands.Cog):
         franchise_role = self._get_franchise_role(ctx, gm.name)
         await franchise_role.delete()
         # TODO: Remove each team within the franchise and their roles
-        await self.prefix_cog.removePrefix(ctx, gm.name)
-        # "Done." message sent in removePrefix function
+        await self.prefix_cog.remove_prefix(ctx, gm.name)
+        await ctx.send("Done.")
 
     @commands.command()
     @commands.guild_only()

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -37,6 +37,7 @@ class TeamManager(commands.Cog):
         franchise_role = await self._create_role(ctx, franchise_role_name)
         await gm.add_roles(gm_role, franchise_role)
         await self.prefix_cog.add_prefix(ctx, gm.name, franchise_prefix)
+        await gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(gm)))
         await ctx.send("Done.")
 
     @commands.command()
@@ -49,6 +50,7 @@ class TeamManager(commands.Cog):
         await franchise_role.delete()
         # TODO: Remove each team within the franchise and their roles
         await self.prefix_cog.remove_prefix(ctx, gm.name)
+        await gm.edit(nick=self.get_player_nickname(gm))
         await ctx.send("Done.")
 
     @commands.command()
@@ -556,6 +558,16 @@ class TeamManager(commands.Cog):
         tier_role = await self.get_current_tier_role(ctx, user)
         franchise_role = self.get_current_franchise_role(user)
         return await self._find_team_name(ctx, franchise_role, tier_role)
+
+    def get_player_nickname(self, user: discord.Member):
+        if user.nick is not None:
+            array = user.nick.split(' | ', 1)
+            if len(array) == 2:
+                currentNickname = array[1].strip()
+            else:
+                currentNickname = array[0]
+            return currentNickname
+        return user.name
 
     def get_franchise_role_from_name(self, ctx, franchise_name: str):
         for role in ctx.message.guild.roles:

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -152,7 +152,7 @@ class TeamManager(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def addTier(self, ctx, tier_name: str):
-        """Add a tier to the tier list and creates tier roles. 
+        """Add a tier to the tier list and creates corresponding roles. 
         This will need to be done before any transactions can be done for players in this tier"""
         await self._create_role(ctx, tier_name)
         await self._create_role(ctx, "{0}FA".format(tier_name))
@@ -165,7 +165,7 @@ class TeamManager(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def removeTier(self, ctx, tier_name: str):
-        """Remove a tier from the tier list and removes the tier's roles"""
+        """Remove a tier from the tier list and the tier's corresponding roles"""
 
         if len(await self._find_teams_for_tier(ctx, tier_name)) > 0:
             await ctx.send(":x: Cannot remove a tier that has teams enrolled.")

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -42,10 +42,14 @@ class TeamManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @commands.admin_or_permissions(manage_guild=True)
-    async def newRole(self, ctx, role_name: str):
-        role = await self._create_role(ctx, role_name)
-        await ctx.author.add_roles(role)
-        await ctx.send("Done?")
+    async def removeFranchise(self, ctx, gm: discord.Member):
+        gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
+        await gm.remove_roles(gm_role)
+        franchise_role = self._get_franchise_role(ctx, gm.name)
+        await franchise_role.delete()
+        # TODO: Remove each team within the franchise and their roles
+        await self.prefix_cog.removePrefix(ctx, gm.name)
+        # "Done." message sent in removePrefix function
 
     @commands.command()
     @commands.guild_only()
@@ -366,8 +370,6 @@ class TeamManager(commands.Cog):
     async def _create_role(self, ctx, role_name: str):
         """Creates and returns a new Guild Role"""
         return await ctx.guild.create_role(name=role_name)
-
-    async def _remove_role(self, ctx, role_)
 
     def _format_team_member_for_message(self, member, *args):
         extraRoles = list(args)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -26,6 +26,32 @@ class TeamManager(commands.Cog):
         self.config.register_guild(**defaults)
         self.prefix_cog = bot.get_cog("PrefixManager")
 
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def addFranchise(self, ctx, gm: discord.Member, franchise_name: str, franchise_prefix: str):
+        """Add a single franchise and prefix"""
+        gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
+        franchise_role_name = "{0} ({1})".format(franchise_name, gm_name)
+        franchise_role = self._create_role(franchise_role_name) # create role for <frachise> (<gm_name>)
+        await gm.add_roles(gm_role, franchise_role)
+
+        gm_name = gm.name
+        await self.prefix_cog.addPrefix(ctx, gm_name, franchise_prefix)
+        # self._create_role(franchise_role_name)
+        
+        # assign General Manager role to gm
+        await ctx.send("Done")
+
+    @commands.command()
+    @commands.guild_only()
+    @commands.admin_or_permissions(manage_guild=True)
+    async def newRole(self, ctx, role_name: str):
+        role = await self._create_role(ctx, role_name)
+        await ctx.author.add_roles(role)
+        await ctx.send("Done?")
+
     @commands.command()
     @commands.guild_only()
     async def franchises(self, ctx):
@@ -341,6 +367,9 @@ class TeamManager(commands.Cog):
             message += "No known members."
         message += "```"
         return message
+
+    async def _create_role(self, ctx, role_name: str):
+        return await ctx.guild.create_role(name=role_name)
 
     def _format_team_member_for_message(self, member, *args):
         extraRoles = list(args)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -59,13 +59,13 @@ class TeamManager(commands.Cog):
     @commands.guild_only()
     @commands.admin_or_permissions(manage_guild=True)
     async def removeFranchise(self, ctx, gm: discord.Member):
-        gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
-        await gm.remove_roles(gm_role)
         franchise_role = self._get_franchise_role(ctx, gm.name)
         franchise_teams = await self._find_teams_for_franchise(ctx, franchise_role)
         if len(franchise_teams) > 0:
             await ctx.send(":x: Cannot remove a franchise that has teams enrolled.")
         else:
+            gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
+            await gm.remove_roles(gm_role)
             await franchise_role.delete()
             await self.prefix_cog.remove_prefix(ctx, gm.name)
             try: 
@@ -165,7 +165,7 @@ class TeamManager(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def removeTier(self, ctx, tier_name: str):
-        """Remove a tier from the tier list"""
+        """Remove a tier from the tier list and removes the tier's roles"""
 
         if len(await self._find_teams_for_tier(ctx, tier_name)) > 0:
             await ctx.send(":x: Cannot remove a tier that has teams enrolled.")

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -33,16 +33,11 @@ class TeamManager(commands.Cog):
     async def addFranchise(self, ctx, gm: discord.Member, franchise_name: str, franchise_prefix: str):
         """Add a single franchise and prefix"""
         gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
-        franchise_role_name = "{0} ({1})".format(franchise_name, gm_name)
-        franchise_role = self._create_role(franchise_role_name) # create role for <frachise> (<gm_name>)
+        franchise_role_name = "{0} ({1})".format(franchise_name, gm.name)
+        franchise_role = await self._create_role(ctx, franchise_role_name)
         await gm.add_roles(gm_role, franchise_role)
-
-        gm_name = gm.name
-        await self.prefix_cog.addPrefix(ctx, gm_name, franchise_prefix)
-        # self._create_role(franchise_role_name)
-        
-        # assign General Manager role to gm
-        await ctx.send("Done")
+        await self.prefix_cog.add_prefix(ctx, gm.name, franchise_prefix)
+        await ctx.send("Done.")
 
     @commands.command()
     @commands.guild_only()
@@ -369,7 +364,10 @@ class TeamManager(commands.Cog):
         return message
 
     async def _create_role(self, ctx, role_name: str):
+        """Creates and returns a new Guild Role"""
         return await ctx.guild.create_role(name=role_name)
+
+    async def _remove_role(self, ctx, role_)
 
     def _format_team_member_for_message(self, member, *args):
         extraRoles = list(args)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -30,13 +30,15 @@ class TeamManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def addFranchise(self, ctx, gm: discord.Member, franchise_name: str, franchise_prefix: str):
+    async def addFranchise(self, ctx, gm: discord.Member, franchise_prefix: str, *franchise_name: str):
         """Add a single franchise and prefix
         
         This will also create the franchise role in the format: <franchise name> (GM name)
         
-        Afterwards it will assign this role and the General Manager role to the new GM
+        Afterwards it will assign this role and the General Manager role to the new GM and modify their nickname
         """
+        franchise_name = ' '.join(franchise_name)
+        await ctx.send("Team Name: {0} ({1})".format(franchise_name, franchise_prefix))
         gm_role = self._find_role_by_name(ctx, TeamManager.GM_ROLE)
         franchise_role_name = "{0} ({1})".format(franchise_name, gm.name)
         franchise_role = await self._create_role(ctx, franchise_role_name)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -265,6 +265,7 @@ class TeamManager(commands.Cog):
     @checks.admin_or_permissions(manage_guild=True)
     async def removeTeam(self, ctx, team_name: str):
         """Removes team from the file system. Team roles will be cleared as well"""
+        franchise_role, tier_role = await self._roles_for_team(ctx, team_name)
         teams = await self._teams(ctx)
         team_roles = await self._team_roles(ctx)
         try:
@@ -276,6 +277,8 @@ class TeamManager(commands.Cog):
             return
         await self._save_teams(ctx, teams)
         await self._save_team_roles(ctx, team_roles)
+        gm = self._get_gm(ctx, franchise_role)
+        await gm.remove_roles(tier_role)
         await ctx.send("Done.")
 
     @commands.command()
@@ -495,6 +498,8 @@ class TeamManager(commands.Cog):
             return False
         await self._save_teams(ctx, teams)
         await self._save_team_roles(ctx, team_roles)
+        gm = self._get_gm(ctx, franchise_role)
+        await gm.add_roles(tier_role)
         return True
 
     def _get_tier_role(self, ctx, tier: str):

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -45,7 +45,10 @@ class TeamManager(commands.Cog):
         if franchise_role and not self.is_gm(gm):
             await gm.add_roles(gm_role, franchise_role)
             await self.prefix_cog.add_prefix(ctx, gm.name, franchise_prefix)
-            # await gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(gm)))
+            try:
+                await gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(gm)))
+            except discord.Forbidden:
+                await ctx.send("Chaning nickname forbidden for user: {0}".format(gm.name))
             await ctx.send("Done.")
         else:
             if self.is_gm(gm):
@@ -65,7 +68,10 @@ class TeamManager(commands.Cog):
         else:
             await franchise_role.delete()
             await self.prefix_cog.remove_prefix(ctx, gm.name)
-            # await gm.edit(nick=self.get_player_nickname(gm))
+            try: 
+                await gm.edit(nick=self.get_player_nickname(gm))
+            except:
+                await ctx.send("Chaning nickname forbidden for user: {0}".format(gm.name))
             await ctx.send("Done.")
 
     @commands.command()

--- a/transactions/transactions.py
+++ b/transactions/transactions.py
@@ -264,14 +264,7 @@ class Transactions(commands.Cog):
         return free_agent_roles
 
     def get_player_nickname(self, user : discord.Member):
-        if user.nick is not None:
-            array = user.nick.split(' | ', 1)
-            if len(array) == 2:
-                currentNickname = array[1].strip()
-            else:
-                currentNickname = array[0]
-            return currentNickname
-        return user.name
+        return self.team_manager_cog.get_player_nickname()
 
     def _get_gm_name(self, ctx, franchise_role, returnNameAsString=False):
         gm = self.team_manager_cog._get_gm(ctx, franchise_role)


### PR DESCRIPTION
- `<p>addFranchise`: adds prefix, franchise role, and GM role to new GM, and edits nickname to include franchise prefix
- `<p>removeFranchise`: removes GM roles, deletes franchise role, removes prefix from nickname
- `<p>addTier`: now adds <tier> and <tierFA> role
- `<p>removeTier`: removes <tier> and <tierFA> roles
- `<p>addTeam`: adds <tier> role to new team's GM
- `<p>removeTeam`: removes <tier> role from GM
- Updated readme to reflect changes.

Notes: 
- nickname will not be modified for individuals with roles that "outrank" the bot's roles.
- Tiers/Franchises will not be removed if they contain teams