### PR TITLE
Transfer ownership

### DIFF
--- a/prefixManager/prefixManager.py
+++ b/prefixManager/prefixManager.py
@@ -199,7 +199,7 @@ class PrefixManager(commands.Cog):
         except:
             return None
 
-    async def get_franchise_prefix(self, ctx, franchise_role):
+    async def _get_franchise_prefix(self, ctx, franchise_role):
         prefixes = await self._prefixes(ctx)
         try:
             gm_name = re.findall(r'(?<=\().*(?=\))', franchise_role.name)[0]

--- a/prefixManager/prefixManager.py
+++ b/prefixManager/prefixManager.py
@@ -171,7 +171,7 @@ class PrefixManager(commands.Cog):
         await self._save_prefixes(ctx, prefixes)
         return True
 
-    async def remove_prefix(ctx, gm_name: str):
+    async def remove_prefix(self, ctx, gm_name: str):
         prefixes = await self._prefixes(ctx)
         try:
             del prefixes[gm_name]

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -96,12 +96,6 @@ class TeamManager(commands.Cog):
         await self._remove_team(ctx, old_team_name)
         await self._add_team(ctx, new_gm.name, tier_role.name, new_team_name)
 
-        # for each player, replace franchise role, change nickname
-        for player in team_players:
-            await player.remove_roles(old_franchise_role)
-            await player.add_roles(new_franchise_role)
-            await self._set_user_nickname_prefix(ctx, new_franchise_prefix, player)
-
         await ctx.send("Done.")
 
     @commands.command()

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -85,11 +85,11 @@ class TeamManager(commands.Cog):
         new_franchise_prefix = await self.prefix_cog.get_franchise_prefix(ctx, new_franchise_role)
         old_franchise_role, tier_role = await self._roles_for_team(ctx, old_team_name)
         old_gm, team_players = self.gm_and_members_from_team(ctx, old_franchise_role, tier_role)
-        # remove team tier role from GM, add to new gm (Should be done in add/remove team functions)
+        # TODO: remove team tier role from GM, add to new gm (Should be done in add/remove team functions)
         
         # make sure new_gm doesn't already have a team at that tier
         if tier_role in new_gm.roles:
-            await ctx.send(":x: {0} already has a team in the {1} tier.")
+            await ctx.send(":x: {0} already has a team in the {1} tier.".format(new_gm, tier_role.name))
             return
 
         # Move Team from old to new franchise/gm ownership

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -43,12 +43,9 @@ class TeamManager(commands.Cog):
 
         # reassign roles for gm/franchise
         franchise_tier_roles = await self._get_user_tier_roles(ctx, old_gm)
-        # transfer_roles = gm_role + franchise_role + franchise_tier_roles
-
-        await new_gm.add_roles(franchise_role, gm_role)
-        await old_gm.remove_roles(franchise_role, gm_role)
-        await new_gm.add_roles(franchise_tier_roles)
-        await old_gm.remove_roles(franchise_tier_roles)
+        transfer_roles = [gm_role, franchise_role] + franchise_tier_roles
+        await new_gm.add_roles(*transfer_roles)
+        await old_gm.remove_roles(*transfer_roles)
         
         # rename franchise
         franchise_name = self.get_franchise_name_from_role(franchise_role)
@@ -631,6 +628,6 @@ class TeamManager(commands.Cog):
         for tier_name in await self._tiers(ctx):
             tier_role = self._find_role_by_name(ctx, tier_name)
             if tier_role in user.roles:
-                user_tier_roles.append(user_tier_roles)
+                user_tier_roles.append(tier_role)
         return user_tier_roles
 

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -64,6 +64,7 @@ class TeamManager(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
     async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, *, new_team_name: str):
         """Transfers ownership of a franchise to a new GM"""
         if not self.is_gm(old_gm):
@@ -98,6 +99,9 @@ class TeamManager(commands.Cog):
 
         await ctx.send("Done.")
 
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
     async def addFranchise(self, ctx, gm: discord.Member, franchise_prefix: str, *, franchise_name: str):
         """Add a single franchise and prefix
         This will also create the franchise role in the format: <franchise name> (GM name)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -290,14 +290,14 @@ class TeamManager(commands.Cog):
 
         teams_to_add -- One or more teams in the following format:
         ```
-        "['<gm_name>','<tier>','<team_name>']"
+        "['<team_name>','<gm_name>','<tier>']"
         ```
         Each team should be separated by a space.
 
         Examples:
         ```
-        [p]addTeams "['Shamu','Challenger','Derechos']"
-        [p]addTeams "['Shamu','Challenger','Derechos']" "['Snipe','Challenger','Barbarians']"
+        [p]addTeams "['Derechos','Shamu','Challenger']"
+        [p]addTeams "['Derechos','Shamu','Challenger']" "['Barbarians','Snipe','Challenger']"
         ```
         """
         addedCount = 0
@@ -315,9 +315,9 @@ class TeamManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def addTeam(self, ctx, gm_name: str, tier: str, *, team_name: str):
+    async def addTeam(self, ctx, team_name: str, gm_name: str, tier: str):
         """Add a single team and it's corresponding roles to the file system to be used for transactions and match info"""
-        teamAdded = await self._add_team(ctx, gm_name, tier, team_name)
+        teamAdded = await self._add_team(ctx, team_name, gm_name, tier)
         if(teamAdded):
             await ctx.send("Done.")
         else:
@@ -517,8 +517,7 @@ class TeamManager(commands.Cog):
         tier_matches = re.findall(r'\w*\b(?=\))', team_role.name)
         return None if not tier_matches else tier_matches[0]
 
-    async def _add_team(self, ctx, gm_name: str, tier: str, *team_name: str):
-        team_name = " ".join(team_name)
+    async def _add_team(self, ctx, team_name: str, gm_name: str, tier: str):
         teams = await self._teams(ctx)
         team_roles = await self._team_roles(ctx)
 

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -58,15 +58,8 @@ class TeamManager(commands.Cog):
         await self.prefix_cog.add_prefix(ctx, new_gm.name, franchise_prefix)
 
         # change nicknames
-        try:
-            await new_gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(new_gm)))
-        except discord.Forbidden:
-            await ctx.send("Chaning nickname forbidden for user: {0}".format(new_gm.name))
-        try:
-            await old_gm.edit(nick="{0}".format(self.get_player_nickname(old_gm)))
-        except discord.Forbidden:
-            await ctx.send("Chaning nickname forbidden for user: {0}".format(old_gm.name))
-
+        await self._set_user_nickname_prefix(ctx, franchise_prefix, new_gm)
+        await self._set_user_nickname_prefix(ctx, None, old_gm)
         await ctx.send("Done.")
 
     @commands.command()
@@ -101,7 +94,7 @@ class TeamManager(commands.Cog):
         for player in team_players:
             await player.remove_roles(old_franchise_role)
             await player.add_roles(new_franchise_role)
-            await 
+            # await self._set_user_nickname_prefix(ctx, new_franchise_prefix, player)
             try:
                 await player.edit(nick="{0} | {1}".format(new_franchise_prefix, self.get_player_nickname(player)))
             except discord.Forbidden:
@@ -111,9 +104,7 @@ class TeamManager(commands.Cog):
 
     async def addFranchise(self, ctx, gm: discord.Member, franchise_prefix: str, *franchise_name: str):
         """Add a single franchise and prefix
-        
         This will also create the franchise role in the format: <franchise name> (GM name)
-        
         Afterwards it will assign this role and the General Manager role to the new GM and modify their nickname
         """
         franchise_name = ' '.join(franchise_name)
@@ -124,10 +115,7 @@ class TeamManager(commands.Cog):
         if franchise_role and not self.is_gm(gm):
             await gm.add_roles(gm_role, franchise_role)
             await self.prefix_cog.add_prefix(ctx, gm.name, franchise_prefix)
-            try:
-                await gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(gm)))
-            except discord.Forbidden:
-                await ctx.send("Chaning nickname forbidden for user: {0}".format(gm.name))
+            await self._set_user_nickname_prefix(ctx, franchise_prefix, gm)
             await ctx.send("Done.")
         else:
             if self.is_gm(gm):
@@ -147,10 +135,7 @@ class TeamManager(commands.Cog):
             await gm.remove_roles(gm_role)
             await franchise_role.delete()
             await self.prefix_cog.remove_prefix(ctx, gm.name)
-            try: 
-                await gm.edit(nick=self.get_player_nickname(gm))
-            except:
-                await ctx.send("Chaning nickname forbidden for user: {0}".format(gm.name))
+            await self._set_user_nickname_prefix(ctx, None, gm)
             await ctx.send("Done.")
 
     @commands.command()
@@ -696,6 +681,15 @@ class TeamManager(commands.Cog):
             return currentNickname
         return user.name
 
+    async def _set_user_nickname_prefix(self, ctx, prefix: str, user: discord.member):
+        try:
+            if prefix:
+                await user.edit(nick="{0} | {1}".format(prefix, self.get_player_nickname(user)))
+            else:
+                await user.edit(nick=self.get_player_nickname(user))
+        except discord.Forbidden:
+            await ctx.send("Chaning nickname forbidden for user: {0}".format(user.name))
+
     def get_franchise_role_from_name(self, ctx, franchise_name: str):
         for role in ctx.message.guild.roles:
             try:
@@ -763,3 +757,5 @@ class TeamManager(commands.Cog):
             if tier_role in user.roles:
                 user_tier_roles.append(tier_role)
         return user_tier_roles
+    
+    

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -74,11 +74,16 @@ class TeamManager(commands.Cog):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(new_gm.name))
             return False
 
+        tier_role = self._get_tier_role(ctx, tier)
+        old_franchise_role = self._get_franchise_role(ctx, old_gm.name)
+        old_team_name = await self._get_franchise_tier_team(ctx, old_franchise_role, tier_role)
         new_franchise_role = self._get_franchise_role(ctx, new_gm.name)
         new_franchise_prefix = await self.prefix_cog._get_franchise_prefix(ctx, new_franchise_role)
-        tier_role = self._get_tier_role(ctx, tier)
         if not tier_role:
             await ctx.send("\"{0}\" does not appear to be a tier.".format(tier))
+            return
+        if not old_team_name:
+            await ctx.send("{0} does not appear to have a {1} team.".format(old_gm.name, tier))
             return
         old_gm, team_players = self.gm_and_members_from_team(ctx, old_franchise_role, tier_role)
         
@@ -650,6 +655,17 @@ class TeamManager(commands.Cog):
                 franchise_teams.append(team)
         return franchise_teams
 
+    async def _get_franchise_tier_team(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):
+        teams = await self._teams(ctx)
+        print(">>")
+        print(">>> {0} - {1}".format(franchise_role.name, tier_role.name))
+        print(">>")
+        for team in teams:
+            print(">> {0} - {1}".format((await self._roles_for_team(ctx, team))[0].name, (await self._roles_for_team(ctx, team))[1].name))
+            if (await self._roles_for_team(ctx, team)) == (franchise_role, tier_role):
+                return team
+        return None
+    
     def get_current_franchise_role(self, user: discord.Member):
         for role in user.roles:
             try:

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -58,6 +58,14 @@ class TeamManager(commands.Cog):
         await self.prefix_cog.add_prefix(ctx, new_gm.name, franchise_prefix)
 
         # change nicknames
+        try:
+            await new_gm.edit(nick="{0} | {1}".format(franchise_prefix, self.get_player_nickname(new_gm)))
+        except discord.Forbidden:
+            await ctx.send("Chaning nickname forbidden for user: {0}".format(new_gm.name))
+        try:
+            await old_gm.edit(nick="{0}".format(self.get_player_nickname(old_gm)))
+        except discord.Forbidden:
+            await ctx.send("Chaning nickname forbidden for user: {0}".format(old_gm.name))
 
         await ctx.send("Done.")
 
@@ -631,3 +639,12 @@ class TeamManager(commands.Cog):
                 user_tier_roles.append(tier_role)
         return user_tier_roles
 
+    def get_player_nickname(self, user: discord.Member):
+        if user.nick is not None:
+            array = user.nick.split(' | ', 1)
+            if len(array) == 2:
+                currentNickname = array[1].strip()
+            else:
+                currentNickname = array[0]
+            return currentNickname
+        return user.name

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -64,7 +64,7 @@ class TeamManager(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, *new_team_name: str):
+    async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, *, new_team_name: str):
         """Transfers ownership of a franchise to a new GM"""
         if not self.is_gm(old_gm):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(old_gm.name))
@@ -73,7 +73,6 @@ class TeamManager(commands.Cog):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(new_gm.name))
             return False
 
-        new_team_name = " ".join(new_team_name)
         new_franchise_role = self._get_franchise_role(ctx, new_gm.name)
         new_franchise_prefix = await self.prefix_cog._get_franchise_prefix(ctx, new_franchise_role)
         tier_role = self._get_tier_role(ctx, tier)
@@ -99,7 +98,7 @@ class TeamManager(commands.Cog):
 
         await ctx.send("Done.")
 
-    async def addFranchise(self, ctx, gm: discord.Member, franchise_prefix: str, *franchise_name: str):
+    async def addFranchise(self, ctx, gm: discord.Member, franchise_prefix: str, *, franchise_name: str):
         """Add a single franchise and prefix
         This will also create the franchise role in the format: <franchise name> (GM name)
         Afterwards it will assign this role and the General Manager role to the new GM and modify their nickname

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -657,11 +657,7 @@ class TeamManager(commands.Cog):
 
     async def _get_franchise_tier_team(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):
         teams = await self._teams(ctx)
-        print(">>")
-        print(">>> {0} - {1}".format(franchise_role.name, tier_role.name))
-        print(">>")
         for team in teams:
-            print(">> {0} - {1}".format((await self._roles_for_team(ctx, team))[0].name, (await self._roles_for_team(ctx, team))[1].name))
             if (await self._roles_for_team(ctx, team)) == (franchise_role, tier_role):
                 return team
         return None

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -71,8 +71,7 @@ class TeamManager(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def transferTeam(self, ctx, old_gm: discord.Member, old_team_name: str, new_gm: discord.Member, new_team_name: str):
+    async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, new_team_name: str):
         """Transfers ownership of a franchise to a new GM"""
         if not self.is_gm(old_gm):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(old_gm.name))
@@ -83,7 +82,10 @@ class TeamManager(commands.Cog):
 
         new_franchise_role = self._get_franchise_role(ctx, new_gm.name)
         new_franchise_prefix = await self.prefix_cog._get_franchise_prefix(ctx, new_franchise_role)
-        old_franchise_role, tier_role = await self._roles_for_team(ctx, old_team_name)
+        tier_role = self._get_tier_role(ctx, tier)
+        if not tier_role:
+            await ctx.send("\"{0}\" does not appear to be a tier.".format(tier))
+            return
         old_gm, team_players = self.gm_and_members_from_team(ctx, old_franchise_role, tier_role)
         
         # make sure new_gm doesn't already have a team at that tier
@@ -99,6 +101,7 @@ class TeamManager(commands.Cog):
         for player in team_players:
             await player.remove_roles(old_franchise_role)
             await player.add_roles(new_franchise_role)
+            await 
             try:
                 await player.edit(nick="{0} | {1}".format(new_franchise_prefix, self.get_player_nickname(player)))
             except discord.Forbidden:

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -72,7 +72,7 @@ class TeamManager(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def transferTeam(self, ctx, old_gm: discord.Member, new_gm: discord.Member, old_team_name: str, new_team_name=old_team_name):
+    async def transferTeam(self, ctx, old_gm: discord.Member, old_team_name: str, new_gm: discord.Member, new_team_name: str):
         """Transfers ownership of a franchise to a new GM"""
         if not self.is_gm(old_gm):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(old_gm.name))
@@ -83,8 +83,8 @@ class TeamManager(commands.Cog):
 
         new_franchise_role = self._get_franchise_role(ctx, new_gm.name)
         new_franchise_prefix = await self.prefix_cog.get_franchise_prefix(ctx, new_franchise_role)
-        old_franchise_role, tier_role = await self._roles_for_team(self, ctx, old_team_name)
-        old_gm, team_players = self.gm_and_members_from_team(ctx, franchise_role, tier_role)
+        old_franchise_role, tier_role = await self._roles_for_team(ctx, old_team_name)
+        old_gm, team_players = self.gm_and_members_from_team(ctx, old_franchise_role, tier_role)
         # remove team tier role from GM, add to new gm (Should be done in add/remove team functions)
         
         # make sure new_gm doesn't already have a team at that tier

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -29,7 +29,7 @@ class TeamManager(commands.Cog):
     
     @commands.command()
     @commands.guild_only()
-    @checks.admin_or_permissions("manage_guild"=True)
+    @checks.admin_or_permissions(manage_guild=True)
     async def transferFranchise(ctx, old_gm: discord.Member, new_gm: discord.Member):
         if not is_gm(old_gm):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(old_gm))

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -64,7 +64,7 @@ class TeamManager(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, new_team_name: str):
+    async def transferTeam(self, ctx, old_gm: discord.Member, tier: str, new_gm: discord.Member, *new_team_name: str):
         """Transfers ownership of a franchise to a new GM"""
         if not self.is_gm(old_gm):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(old_gm.name))
@@ -94,11 +94,7 @@ class TeamManager(commands.Cog):
         for player in team_players:
             await player.remove_roles(old_franchise_role)
             await player.add_roles(new_franchise_role)
-            # await self._set_user_nickname_prefix(ctx, new_franchise_prefix, player)
-            try:
-                await player.edit(nick="{0} | {1}".format(new_franchise_prefix, self.get_player_nickname(player)))
-            except discord.Forbidden:
-                await ctx.send("Chaning nickname forbidden for user: {0}".format(player.name))
+            await self._set_user_nickname_prefix(ctx, new_franchise_prefix, player)
 
         await ctx.send("Done.")
 

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -73,6 +73,7 @@ class TeamManager(commands.Cog):
             await ctx.send("{0} does not have the \"General Manager\" role.".format(new_gm.name))
             return False
 
+        new_team_name = " ".join(new_team_name)
         new_franchise_role = self._get_franchise_role(ctx, new_gm.name)
         new_franchise_prefix = await self.prefix_cog._get_franchise_prefix(ctx, new_franchise_role)
         tier_role = self._get_tier_role(ctx, tier)

--- a/transactions/transactions.py
+++ b/transactions/transactions.py
@@ -103,7 +103,7 @@ class Transactions(commands.Cog):
                     role_name = "{0}FA".format((await self.team_manager_cog.get_current_tier_role(ctx, user)).name)
                     tier_fa_role = self.team_manager_cog._find_role_by_name(ctx, role_name)
                 fa_role = self.team_manager_cog._find_role_by_name(ctx, "Free Agent")
-                await user.edit(nick="FA | {0}".format(self.get_player_nickname(user)))
+                await team_manager_cog._set_user_nickname_prefix(ctx, "FA", user)
                 await user.add_roles(tier_fa_role, fa_role)
                 gm_name = self._get_gm_name(ctx, franchise_role)
                 message = "{0} was cut by the {1} ({2} - {3})".format(user.mention, team_name, gm_name, tier_role.name)
@@ -240,8 +240,7 @@ class Transactions(commands.Cog):
                 currentTier = await self.team_manager_cog.get_current_tier_role(ctx, user)
                 if currentTier is not None and currentTier != tier_role:
                     await user.remove_roles(currentTier)
-                await user.edit(nick="{0} | {1}".format(prefix, self.get_player_nickname(user)))
-                await 
+                await team_manager_cog._set_user_nickname_prefix(ctx, prefix, user)
                 await user.add_roles(tier_role, leagueRole, franchise_role)
 
 

--- a/transactions/transactions.py
+++ b/transactions/transactions.py
@@ -241,6 +241,7 @@ class Transactions(commands.Cog):
                 if currentTier is not None and currentTier != tier_role:
                     await user.remove_roles(currentTier)
                 await user.edit(nick="{0} | {1}".format(prefix, self.get_player_nickname(user)))
+                await 
                 await user.add_roles(tier_role, leagueRole, franchise_role)
 
 
@@ -276,7 +277,10 @@ class Transactions(commands.Cog):
         return free_agent_roles
 
     def get_player_nickname(self, user : discord.Member):
-        return self.team_manager_cog.get_player_nickname()
+        return self.team_manager_cog.get_player_nickname(user)
+    
+    async def set_user_nickname_prefix(self, ctx, prefix: str, user: discord.member):
+        return self.team_manager_cog._set_user_nickname_prefix(ctx, prefix, user)
 
     async def get_tier_role_for_fa(self, ctx, user : discord.Member):
         fa_roles = await self.find_user_free_agent_roles(ctx, user)


### PR DESCRIPTION
`<p>transferFranchise` allows ownership of a franchise may be given to another GM.
Procedure:
- replaces prefix associated with old GM, with the new GM (i.e. "Adammast = OCE" => "nullidea = OCE")
- edits franchise role name (i.e. "The Ocean (Adammast)" => "The Ocean (nullidea)")
- adds GM role, franchise role, and franchise tier roles to new GM
- adds aliases `claimFranchise` and `recoverFranchise`
- "old_gm" parameter replaced with "franchise_identifier" which can be the old GM, or the franchise name or prefix.
- **If the old GM is still present,** removes GM role, franchise role, and franchise tier roles from old GM, and adds "Former GM" role if it is present in the server.

`<p>transferTeam` allows a GM to give another GM their team at that tier.
Procedure:
- removes tier role from old GM
- gives tier role to new GM
- ~~replaces team players' old franchise role with new franchise role~~
- ~~gives each player the new franchise prefix~~


Other changes:
- refactors `<p>addFranchise` parameters to keep consistency with other commands (*-syntax)
- refactors nickname/prefix editing to use the function `_set_user_nickname_prefix`
- ~~`<p>removeTeam` can remove teams with multi-worded names~~
- ~~refactored `<p>addTeam` and `<p>addTeams` to allow for multi-worded team names, while keeping order consistency~~