### PR TITLE
[p]captains added, [p]roster tweaks

### DIFF
--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -467,9 +467,9 @@ class TeamManager(commands.Cog):
         teams = await self._find_teams_for_franchise(ctx, franchise_role)
         message = ""
         for team in teams:
-            f_role, tier_role = await self._roles_for_team(ctx, team) # TODO: improve this
+            f_role, tier_role = await self._roles_for_team(ctx, team) # TODO: maybe improve this
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
-            message += "\n{0} = {1}".format(team, captain)
+            message += "\n{0} ({1})".format(captain.mention, team)
 
         embed = discord.Embed(title="Captains for {0}:".format(franchise_role.name), color=discord.Colour.blue(), description=message)
         emoji = await self._get_franchise_emoji(ctx, franchise_role)
@@ -480,14 +480,15 @@ class TeamManager(commands.Cog):
     async def _format_tier_captains(self, ctx, tier: str):
         tier_role = self._get_tier_role(ctx, tier)
         teams = await self._find_teams_for_tier(ctx, tier)
-        message = ""
+        captains = []
         for team in teams:
             franchise_role, tier_role = await self._roles_for_team(ctx, team)
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
-            message += "\n{0} = {1}".format(team, captain)
+            captains.append("{0} ({1})".format(captain.mention, team))
+        captains.sort()
+        message = '\n'.join(captains)
 
-        embed = discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color, description=message)
-        return embed
+        return discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color, description=message)
 
     async def _get_team_captain(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):
         captain_role = self._find_role_by_name(ctx, "Captain")

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -173,13 +173,11 @@ class TeamManager(commands.Cog):
         tiers = await self._tiers(ctx)
         for tier in tiers:
             if tier.lower() == franchise_tier_prefix.lower():
-                pass
-                # found = True
+                found = True
+                await ctx.send(embed=await self._format_tier_captains(ctx, tier))
+                return
         
-        if not found:
-            await ctx.send("No franchise, tier, or prefix with name: {0}".format(franchise_tier_prefix))
-
-        
+        await ctx.send("No franchise, tier, or prefix with name: {0}".format(franchise_tier_prefix))
 
 
     @commands.command()
@@ -477,6 +475,18 @@ class TeamManager(commands.Cog):
         emoji = await self._get_franchise_emoji(ctx, franchise_role)
         if(emoji):
             embed.set_thumbnail(url=emoji.url)
+        return embed
+
+    async def _format_tier_captains(self, ctx, tier: str):
+        tier_role = self._get_tier_role(ctx, tier)
+        teams = await self._find_teams_for_tier(ctx, tier)
+        message = ""
+        for team in teams:
+            franchise_role, tier_role = await self._roles_for_team(ctx, team)
+            captain = await self._get_team_captain(ctx, franchise_role, tier_role)
+            message += "\n{0} = {1}".format(team, captain)
+
+        embed = discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color, description=message)
         return embed
 
     async def _get_team_captain(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -140,8 +140,8 @@ class TeamManager(commands.Cog):
     @commands.command(aliases=["captain", "cptn"])
     @commands.guild_only()
     async def captains(self, ctx, *, franchise_tier_prefix: str):
-        """Returns a list of team captains under a franchise based on the input. 
-        You can either give it the name of a franchise, a tier, or the prefix for a franchise.
+        """Returns a list of team captains under a tier or franchise based on the input. 
+        You can either give it the name of a tier, or a franchise identifier (prefix, name, or GM name).
         
         Examples:
         \t[p]captains The Ocean
@@ -242,7 +242,7 @@ class TeamManager(commands.Cog):
                 if len(message) > 1900:
                     messages.append(message)
                     message = ""
-            if message is not "":
+            if message:
                 messages.append(message)
             for msg in messages:
                 await ctx.send("{0}{1}{0}".format("```", msg))
@@ -483,9 +483,8 @@ class TeamManager(commands.Cog):
         
         if not message:
             message = "No captains registered."
-
         elif captainless_teams:
-            message += "No captains found for the following teams:\n"
+            message += "\nNo captains found for the following teams:\n"
             for team in captainless_teams:
                 message += "{0}\n".format(team)
 

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -484,10 +484,13 @@ class TeamManager(commands.Cog):
         for team in teams:
             franchise_role, tier_role = await self._roles_for_team(ctx, team)
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
-            captains.append("{0} ({1})".format(captain.mention, team))
-        captains.sort()
-        message = '\n'.join(captains)
+            captains.append((captain, team))
+        
+        captains.sort(key=lambda captain_team: captain_team[0].name)  # is this bugged, or am I dumb?
 
+        message = ""
+        for captain, team in captains:
+            message += "{0} ({1})\n".format(captain.mention, team)
         return discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color, description=message)
 
     async def _get_team_captain(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):
@@ -498,7 +501,6 @@ class TeamManager(commands.Cog):
                 return member
         return gm
             
-
     async def _create_role(self, ctx, role_name: str):
         """Creates and returns a new Guild Role"""
         for role in ctx.guild.roles:
@@ -544,7 +546,6 @@ class TeamManager(commands.Cog):
         if(emoji):
             embed.set_thumbnail(url=emoji.url)
         return embed
-
 
     async def _format_teams_for_tier(self, ctx, tier):
         teams = await self._find_teams_for_tier(ctx, tier)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -485,9 +485,8 @@ class TeamManager(commands.Cog):
             franchise_role, tier_role = await self._roles_for_team(ctx, team)
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
             captains.append((captain, team))
+        captains.sort(key=lambda captain_team: captain_team[0].name.casefold())  # dumb.
         
-        captains.sort(key=lambda captain_team: captain_team[0].name)  # is this bugged, or am I dumb?
-
         message = ""
         for captain, team in captains:
             message += "{0} ({1})\n".format(captain.mention, team)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -465,17 +465,29 @@ class TeamManager(commands.Cog):
             message += "  {0}\n".format(
                 self._format_team_member_for_message(member, *role_tags))
         if not team_members:
-            message += "No known members."
+            message += "\nNo other members found."
         message += "```"
         return message
 
     async def _format_franchise_captains(self, ctx, franchise_role: discord.Role):
         teams = await self._find_teams_for_franchise(ctx, franchise_role)
+        captainless_teams = []
         message = ""
         for team in teams:
             f_role, tier_role = await self._roles_for_team(ctx, team) # TODO: maybe improve this
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
-            message += "\n{0} ({1})".format(captain.mention, team)
+            if captain:
+                message += "{0} ({1})\n".format(captain.mention, team)
+            else:
+                captainless_teams.append(team)
+        
+        if not message:
+            message = "No captains registered."
+
+        elif captainless_teams:
+            message += "No captains found for the following teams:\n"
+            for team in captainless_teams:
+                message += "{0}\n".format(team)
 
         embed = discord.Embed(title="Captains for {0}:".format(franchise_role.name), color=discord.Colour.blue(), description=message)
         emoji = await self._get_franchise_emoji(ctx, franchise_role)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -474,7 +474,7 @@ class TeamManager(commands.Cog):
         captainless_teams = []
         message = ""
         for team in teams:
-            f_role, tier_role = await self._roles_for_team(ctx, team) # TODO: maybe improve this
+            f_role, tier_role = await self._roles_for_team(ctx, team)
             captain = await self._get_team_captain(ctx, franchise_role, tier_role)
             if captain:
                 message += "{0} ({1})\n".format(captain.mention, team)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -137,7 +137,7 @@ class TeamManager(commands.Cog):
                     message += " `{0}`".format(possible_team)
             await ctx.send(message)
 
-    @commands.command(aliases=["captain", "cptn"])
+    @commands.command(aliases=["captain", "cptn", "cptns"])
     @commands.guild_only()
     async def captains(self, ctx, *, franchise_tier_prefix: str):
         """Returns a list of team captains under a tier or franchise based on the input. 

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -510,18 +510,24 @@ class TeamManager(commands.Cog):
         captains.sort(key=lambda captain_team: captain_team[0].name.casefold())  # dumb.
         captainless_teams.sort(key=lambda gm_team: gm_team[0].name.casefold())
         
-        message = ""
+        embed = discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color)
+
+        captains_formatted = []
+        teams_formatted = []
         if captains:
             for captain, team in captains:
-                message += "{0} ({1})\n".format(captain.mention, team)
-        else:
-            message += "No Captains found in this tier.\n"
+                captains_formatted.append(captain.mention)
+                teams_formatted.append(team)
+                
         if captainless_teams:
-            message += "\nTeams without registered captains:\n"
             for gm, team in captainless_teams:
-                message += "{0} ({1})\n".format(gm.mention, team)
-
-        return discord.Embed(title="Captains for {0}:".format(tier_role.name), color=tier_role.color, description=message)
+                captains_formatted.append("(No Captain)")
+                teams_formatted.append(team)
+            
+        embed.add_field(name="Captain", value="{}\n".format("\n".join(captains_formatted)), inline=True)
+        embed.add_field(name="Team", value="{}\n".format("\n".join(teams_formatted)), inline=True)
+        
+        return embed
 
     async def _get_team_captain(self, ctx, franchise_role: discord.Role, tier_role: discord.Role):
         captain_role = self._find_role_by_name(ctx, "Captain")


### PR DESCRIPTION
**[p]captains added**
- aliases: captain, cptn, cptns
- behavior: responds with an embedded message, listing all the captains that match the given input (tier, or franchise)
- format:  `<captain mention> (<team name>)`
- (i.e.`@rogers (Stingrays)`)
- if no captain is found, the bottom of the list will match the same format, but link the GM in place of a missing captain.

resolves #87 

**[p]roster changes**
- Captain role is passed in externally (avoids repeating captains)
- "GM" role uses insert(0, "GM") to keep that tag listed first
- "No known members" => "No other members found" because GM is always listed.

**Misc:**
- changed `if message is not ""` to `if message` in listTeams
