### PR TITLE
[p]getId can find ID of member by nickname without franchise prefix

### DIFF
--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -232,7 +232,7 @@ class BulkRoleManager(commands.Cog):
                 for match in match_indicies:
                     found[match] = "{1}:{0.name}#{0.discriminator}:{0.id}\n".format(player, player_nick)
         
-        if len(notFound) > 0:
+        if notFound:
             notFoundMessage = ":x: Couldn't find:\n"
             for user in notFound:
                 notFoundMessage += "{0}\n".format(user)
@@ -249,7 +249,8 @@ class BulkRoleManager(commands.Cog):
                     message = ""
             messages.append(message)
         for msg in messages:
-            await ctx.send("{0}{1}{0}".format("```", msg))
+            if msg:
+                await ctx.send("{0}{1}{0}".format("```", msg))
 
     @commands.command()
     @commands.guild_only()

--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -218,9 +218,6 @@ class BulkRoleManager(commands.Cog):
                 if member in ctx.guild.members:
                     nickname = self.get_player_nickname(member)
                     found.append("{1}:{0.name}#{0.discriminator}:{0.id}\n".format(member, nickname))
-                # if len(message) > 1900:
-                #     messages.append(message)
-                #     message = ""
             except:
                 notFound.append(user)
                 found.append(None)
@@ -229,9 +226,11 @@ class BulkRoleManager(commands.Cog):
         for player in ctx.guild.members:
             player_nick = self.get_player_nickname(player)
             if player_nick in notFound:
-                notFound.remove(player_nick)
-                i = userList.index(player_nick)
-                found[i] = "{1}:{0.name}#{0.discriminator}:{0.id}\n".format(player, player_nick)
+                while player_nick in notFound:
+                    notFound.remove(player_nick)
+                match_indicies = [i for i, x in enumerate(userList) if x == player_nick]
+                for match in match_indicies:
+                    found[match] = "{1}:{0.name}#{0.discriminator}:{0.id}\n".format(player, player_nick)
         
         if len(notFound) > 0:
             notFoundMessage = ":x: Couldn't find:\n"
@@ -243,7 +242,7 @@ class BulkRoleManager(commands.Cog):
         if found:
             message = ""
             for member_line in found:
-                if len(message + member_line) < 2000:
+                if member_line and len(message + member_line) < 2000:
                     message += member_line
                 else:
                     messages.append(message)

--- a/bulkRoleManager/bulkRoleManager.py
+++ b/bulkRoleManager/bulkRoleManager.py
@@ -205,30 +205,49 @@ class BulkRoleManager(commands.Cog):
             message += ". {0} user(s) had the role added to them".format(added)
         await ctx.send(message)
     
-    @commands.command()
+    @commands.command(aliases=["getID", "getid"])
     @commands.guild_only()
     async def getId(self, ctx, *userList):
         """Gets the id for any user that can be found from the userList"""
+        found = []
         notFound = []
-        messages = []
-        message = ""
+        # message = ""
         for user in userList:
             try:
                 member = await commands.MemberConverter().convert(ctx, user)
                 if member in ctx.guild.members:
                     nickname = self.get_player_nickname(member)
-                    message += "{1}:{0.name}#{0.discriminator}:{0.id}\n".format(member, nickname)
-                if len(message) > 1900:
-                    messages.append(message)
-                    message = ""
+                    found.append("{1}:{0.name}#{0.discriminator}:{0.id}\n".format(member, nickname))
+                # if len(message) > 1900:
+                #     messages.append(message)
+                #     message = ""
             except:
                 notFound.append(user)
+                found.append(None)
+        
+        # Double Check not found (search by nickname without prefix):
+        for player in ctx.guild.members:
+            player_nick = self.get_player_nickname(player)
+            if player_nick in notFound:
+                notFound.remove(player_nick)
+                i = userList.index(player_nick)
+                found[i] = "{1}:{0.name}#{0.discriminator}:{0.id}\n".format(player, player_nick)
+        
         if len(notFound) > 0:
             notFoundMessage = ":x: Couldn't find:\n"
             for user in notFound:
                 notFoundMessage += "{0}\n".format(user)
             await ctx.send(notFoundMessage)
-        if message is not "":
+        
+        messages = []
+        if found:
+            message = ""
+            for member_line in found:
+                if len(message + member_line) < 2000:
+                    message += member_line
+                else:
+                    messages.append(message)
+                    message = ""
             messages.append(message)
         for msg in messages:
             await ctx.send("{0}{1}{0}".format("```", msg))


### PR DESCRIPTION
Refactored `[p]getId`
- This command will now also find members by nickname without the franchise prefix.
- i.e. a player with the nickname "SOV | nullidea" can be found by `[p]getId "SOV | nullidea"` or (new:) `[p]getId nullidea`
- refactored character limit check
- players found print in the order they are requested in the command