### PR TITLE
fixes response for franchises with no captains set

### DIFF
--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -489,8 +489,8 @@ class TeamManager(commands.Cog):
                     # captains_mentioned.append(captain.mention) # mention disabled
                     captains_username.append(str(captain))
                 else:
-                    captains_mentioned.append("(No captain)")
-                    # captains_username.append("N/A") # mention disabled
+                    # captains_mentioned.append("(No captain)")
+                    captains_username.append("(No captain)")  #.append("N/A") # mention disabled
         else:
             message += "\nNo teams have been made."
 
@@ -536,8 +536,8 @@ class TeamManager(commands.Cog):
                 
         if captainless_teams:
             for gm, team in captainless_teams:
-                captains_formatted.append("N/A")
-                captains_mentioned_formatted.append("(No Captain)")
+                captains_formatted.append("(No captain)")  #.append("N/A")
+                # captains_mentioned_formatted.append("(No Captain)")
                 teams_formatted.append(team)
         
         embed.add_field(name="Team", value="{}\n".format("\n".join(teams_formatted)), inline=True)


### PR DESCRIPTION
When no captains were set for a franchise, an error would be thrown. This has been resolved.

Update: 
- "N/A" has been changed to "(No captain)" for teams without captains.