### PR TITLE
Nuke Combines

### DIFF
--- a/combineRooms/README.md
+++ b/combineRooms/README.md
@@ -19,37 +19,24 @@ The `combineRooms` cog depends on the `teamManager` cog. Install `teamManager` a
 - `<p>stopcombines`
   Runs a teardown for all combine channels. This will remove all channels under the "Combine Rooms" categorty as well as the category itself.
 
+### Roles involved:
+- League
+
 ## Customization
 
-- `<p>setPlayersPerRoom` (Default: 6)
-  - Sets the reccomended concurrent FA/DE limit in a room.
-  - (Disabled) The room name will reflect the number of FA/DE players in them
-    - Naming format: `<Rank> room <room number> (<player count>/<players_per_room>)`
-  - Examples:
-    - 3v3 leagues should have no more than 6 Free Agent/Draft Eligible players combined.
-    - 2v2 leagues should have no more than 4 Free Agent/Draft Eligible players combined.
-    - Special case: RSC's 1v1 league will have rooms of 4 players, who will cycle through matches against each other player in the room.
 - `<p>setRoomCapacity` (Default: 10)
-  - Sets the limit for discord members in room. This limit is role agnostic.
-  - This is a limit for players and scouts in a single room.
+  - Sets the limit for discord members in room.
 - `<p>togglePublicity` (Default: Public)
   - Toggles the combines between a Public and Private status.
   - If combines are Public, any member may participate.
   - If combines are Private, only members with the "League" role may particpate.
 - `<p>setAcronym` (Default: RSC)
   - Sets the acronym used in the combines cog.
-  - This is used to tweak the default message in the #combine-details channel, such as rule reference, and room information.
-- `<p>setCombinesMessage <message>`
-  - Sets a custom message that is sent to the #combines-details channel.
-  - To change the combines message back to the default, run either of the following:
-    - `<p>setCombinesMessage clear`
-    - `<p>setCombinesMessage reset`
+  - This is is relevant with the naming scheme for dynamically created voice channels.
 
 ## Other commands
 
 The following commands can be used to check current properties of the server:
-- `<p>getPlayersPerRoom`
 - `<p>getRoomCapacity`
 - `<p>getCombinePublicity`
 - `<p>getAcronym`
-- `<p>getCombinesMessage`

--- a/combineRooms/README.md
+++ b/combineRooms/README.md
@@ -19,8 +19,9 @@ The `combineRooms` cog depends on the `teamManager` cog. Install `teamManager` a
 - `<p>stopcombines`
   Runs a teardown for all combine channels. This will remove all channels under the "Combine Rooms" categorty as well as the category itself.
 
-### Roles involved:
+#### Roles involved:
 - League
+- Muted
 
 ## Customization
 

--- a/combineRooms/README.md
+++ b/combineRooms/README.md
@@ -13,10 +13,10 @@ The `combineRooms` cog depends on the `teamManager` cog. Install `teamManager` a
 
 ## Usage
 
-- `<p>startcombines`
+- `<p>startCombines`
   Creates a Combine Rooms channel category with all associated text and voice channels.
 
-- `<p>stopcombines`
+- `<p>stopCombines`
   Runs a teardown for all combine channels. This will remove all channels under the "Combine Rooms" categorty as well as the category itself.
 
 #### Roles involved:

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -12,20 +12,20 @@ class CombineRooms(commands.Cog):
         self.config.register_guild(**defaults)
         self.team_manager_cog = bot.get_cog("TeamManager")
     
-    @commands.command()
+    @commands.command(aliases=["startcombines"])
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def startcombines(self, ctx):
+    async def startCombines(self, ctx):
         if not await self._combine_category_ids(ctx.guild):
             await self._start_combines(ctx)
             await ctx.send("Combine Rooms have been created.")
             return True
         await ctx.send("Combine Rooms have already been created.")
     
-    @commands.command()
+    @commands.command(aliases=["stopcombines"])
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def stopcombines(self, ctx):
+    async def stopCombines(self, ctx):
         if await self._combine_category_ids(ctx.guild):
             await self._stop_combines(ctx)
             await ctx.send("Combine Rooms have been removed.")

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -104,16 +104,16 @@ class CombineRooms(commands.Cog):
 
     async def _add_combines_category(self, ctx, name: str):
         # check if category exists already
-        overwrites = {}
+        league_role = self._get_role_by_name(ctx.guild, "League")
+        is_public = await self._is_public_combine(ctx.guild)
+        overwrites = {
+            league_role: discord.PermissionOverwrite(view_channel=True, connect=True, send_messages=False),
+            ctx.guild.default_role: discord.PermissionOverwrite(view_channel=is_public, connect=is_public, send_messages=False)
+        }
         muted_role = self._get_role_by_name(ctx.guild, "Muted")
         if muted_role:
             overwrites[muted_role] = discord.PermissionOverwrite(connect=False)
         
-        if not await self._is_public_combine(ctx.guild):
-            league_role = self._get_role_by_name(ctx.guild, "League")
-            overwrites[ctx.guild.default_role] = discord.PermissionOverwrite(view_channel=False, connect=False, send_messages=False)
-            overwrites[league_role] = discord.PermissionOverwrite(view_channel=True, connect=True, send_messages=False)
-
         return await ctx.guild.create_category(name, overwrites=overwrites)
 
     async def _add_combines_voice(self, guild: discord.Guild, tier: str, category: discord.CategoryChannel=None):

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -52,6 +52,27 @@ class CombineRooms(commands.Cog):
         response = "Combines are currently **{0}**.".format(public_str)
         await ctx.send(response)
 
+    @commands.command(aliases=["acronym"])
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def getAcronym(self, ctx):
+        """
+        Gets the acronym registered for combines. (Default: RSC)
+        """
+        acronym = await self._get_acronym(ctx.guild)
+        await ctx.send("The acronym registered for the combines cog is **{0}**.".format(acronym))
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setAcronym(self, ctx, new_acronym: str):
+        """
+        Sets the server acronym used in the combines category. (Default: RSC)
+        This is primarily used in #combine-details message
+        """
+        await self._save_acronym(ctx.guild, new_acronym)
+        await ctx.send("The acronym has been registered as **{0}**.".format(new_acronym))
+
     @commands.command(aliases=["togglePub", "toggleCombines", "togglePublicCombine", "tpc", "toggleCombinePermissions", "tcp"])
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -3,9 +3,7 @@ from redbot.core import Config
 from redbot.core import commands
 from redbot.core import checks
 
-# TODO:
-# - custom combines_info message
-defaults = {"players_per_room": 6, "room_capacity": 10, "combines_category": None, "public_combines": True, "acronym": "RSC", "CustomMessage": None}
+defaults = {"players_per_room": 6, "room_capacity": 10, "Categories": [], "public_combines": True, "acronym": "RSC", "CustomMessage": None}
 
 
 class CombineRooms(commands.Cog):
@@ -13,12 +11,12 @@ class CombineRooms(commands.Cog):
         self.config = Config.get_conf(self, identifier=1234567892, force_registration=True)
         self.config.register_guild(**defaults)
         self.team_manager_cog = bot.get_cog("TeamManager")
-
+    
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def startcombines(self, ctx):
-        if not await self._combines_category(ctx.guild):
+        if not await self._combines_categories(ctx.guild):
             await self._start_combines(ctx)
             await ctx.send("Combine Rooms have been created.")
             return True
@@ -28,366 +26,90 @@ class CombineRooms(commands.Cog):
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
     async def stopcombines(self, ctx):
-        if await self._combines_category(ctx.guild):
+        if await self._combines_categories(ctx.guild):
             await self._stop_combines(ctx)
             await ctx.send("Combine Rooms have been removed.")
             return True
         await ctx.send("No Combine Rooms found.")
-    
-    @commands.command(aliases=["sppr"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def setPlayersPerRoom(self, ctx, size: int):
-        """
-        Sets the recommended amount of concurrent players in combine rooms. (Default: 6)
-        """
-
-        if size < 2:
-            await ctx.send(":x: There is a minimum of 2 players per voice channel.")
-            return False  
-        combines_cat = await self._save_players_per_room(ctx.guild, size)
-        # DISABLED: room size in name
-        # if combines_cat and False:
-        #     for vc in combines_cat.voice_channels:
-        #         await self._adjust_room_(guild, vc)
-        await ctx.send("Done")
-        return True
-    
-    @commands.command(aliases=["ppr"])
-    @commands.guild_only()
-    async def getPlayersPerRoom(self, ctx):
-        """
-        Gets the recommended amount of concurrent players in combine rooms.
-        """
-        size = await self._players_per_room(ctx.guild)
-        await ctx.send("Combines should have no more than {0} active players in them.".format(size))
-
-    @commands.command(aliases=["setroomcap", "src"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def setRoomCapacity(self, ctx, size: int):
-        """
-        Sets the maximum number of members allowed in combine voice channels. (Default: 10)
-        """
-        if size < 2:
-            await ctx.send(":x: There is a minimum of 2 players per voice channel.")
-            return False  
-        combines_cat = await self._save_room_capacity(ctx.guild, size)
-        if self._combines_category(ctx.guild):
-            await ctx.send("Done: Changes will not be applied to rooms that are already up.")
-        else:
-            await ctx.send("Done")
-        return True
-
-    @commands.command(aliases=["roomcap", "grc"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def getRoomCapacity(self, ctx):
-        """
-        Gets the current capacity of combine voice rooms (Default: 10)
-        This capacity is for all members, players and scouts combined.
-        """
-        cap = await self._room_capacity(ctx.guild)
-        await ctx.send("Combines currently have a maximum size of {0} members.".format(cap))
-        return
-
-    @commands.command(aliases=["togglePub", "toggleCombines", "togglePublicCombine", "tpc", "toggleCombinePermissions", "tcp"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def togglePublicity(self, ctx):
-        """
-        Toggles the status (public/private) of the combines. (Default: Public)
-        If combines are **Public**, any member may participate.
-        If combines are **Private**, only members with the "League" role may particpate.
-        """
-        is_public = await self._toggle_public_combine(ctx.guild)
-        await self._update_combine_permissions(ctx.guild)
-
-        public_str = "public" if is_public else "private"
-        response = "Combines are now **{0}**.".format(public_str)
-        await ctx.send(response)
-
-    @commands.command(aliases=["combinePublicity", "checkCombinePublicity", "ccp", "combineStatus", "checkCombineStatus", "ccs"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def getCombinePublicity(self, ctx):
-        """
-        Gets the current status (public/private) of the combines.
-        If combines are **Public**, any member may participate.
-        If combines are **Private**, only members with the "League" role may particpate.
-        """
-        public_str = "public" if await self._is_public_combine(ctx.guild) else "private"
-        response = "Combines are currently **{0}**.".format(public_str)
-        await ctx.send(response)
-
-    @commands.command(aliases=["acronym"])
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def getAcronym(self, ctx):
-        """
-        Gets the acronym registered for combines. (Default: RSC)
-        """
-        acronym = await self._get_acronym(ctx.guild)
-        await ctx.send("The acronym registered for the combines cog is **{0}**.".format(acronym))
 
     @commands.command()
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def setAcronym(self, ctx, new_acronym: str):
-        """
-        Sets the server acronym used in the combines category. (Default: RSC)
-        This is primarily used in #combine-details message
-        """
-        await self._save_acronym(ctx.guild, new_acronym)
-        await ctx.send("The acronym has been registered as **{0}**.".format(new_acronym))
-
-    @commands.command()
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def setCombinesMessage(self, ctx, *, message: str):
-        """
-        Sets a custom message that is sent to the #combines-details channel.
-        To change the combines message back to the default, run either of the following:
-        \t - `[p]setCombinesMessage clear`
-        \t - `[p]setCombinesMessage reset`
-        """
-        if message.lower() in ["clear", "reset"]:
-            await self._set_custom_message(ctx.guild, None)
-        else:
-            await self._set_custom_message(ctx.guild, message)
+    async def clearcombines(self, ctx):
+        await self._save_combines_categories(ctx.guild, [])
         await ctx.send("Done.")
-    
-    @commands.command()
-    @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
-    async def getCombinesMessage(self, ctx):
-        """
-        Gets the currently set information message for the #combines-details channel.
-        """
-        info_message = await self._get_custom_message(ctx.guild)
-        if not info_message:
-            await ctx.send("No custom message has been set. Your default message is...")
-            info_message = await self._get_default_message(ctx)
-        await ctx.send(info_message)
-
-    @commands.Cog.listener("on_voice_state_update")
-    async def on_voice_state_update(self, member, before, after):
-        combines_ongoing = await self._combines_category(member.guild)
-
-        # ignore when combines are not ongoing, or when voice activity is within the same room
-        if not combines_ongoing or before.channel == after.channel:
-            return
-        
-        # Room joined:
-        await self._member_joins_voice(member, after.channel)
-        # Room left:
-        await self._member_leaves_voice(member, before.channel) # TODO: consider disconnected case #@me what does that even mean? this structure should cover everything
 
     async def _start_combines(self, ctx):
-        # Creates combines category and rooms for each tier
-        combines_category = await self._add_combines_category(ctx, "Combine Rooms")
-        await self._save_combine_category(ctx.guild, combines_category)
-
-        if combines_category:
-            await self._add_combines_info_channel(ctx.guild, combines_category, "Combines Details")
-            for tier in await self.team_manager_cog.tiers(ctx):
-                await self._add_combines_voice(ctx.guild, combines_category, tier)
-            return True
-        return False
-
+        # Creates a combines category and room for each tier
+        # await self._add_combines_info_channel(ctx.guild, combines_category, "Combines Details")
+        categories = []
+        for tier in await self.team_manager_cog.tiers(ctx):
+            tier_category = await self._add_combines_category(ctx, "{0} Combines".format(tier))
+            await self._add_combines_voice(ctx.guild, tier, tier_category)
+            categories.append(tier_category.id)
+        await self._save_combines_categories(ctx.guild, categories)
+        return True
+        
     async def _stop_combines(self, ctx):
         # remove combines channels, category
-        combines_category = await self._combines_category(ctx.guild)
-        if combines_category:
-            for channel in combines_category.channels:
-                await channel.delete()
-            await combines_category.delete()
-            return True
-        await ctx.send("could not find combine rooms.")
-        return False
-    
-    async def _update_combine_permissions(self, guild: discord.Guild):
-        combines_category = await self._combines_category(guild)
-        is_public = await self._is_public_combine(guild)
+        saved_categories = await self._combines_categories(ctx.guild)
+        for category in ctx.guild.categories:
+            if category.id in saved_categories:
+                for channel in category.channels:
+                    await channel.delete()
+                await category.delete()
+        await self._save_combines_categories(ctx.guild, None)
 
-        if combines_category:
-            league_role = self._get_role_by_name(guild, "League")
-            overwrites = {
-                guild.default_role: discord.PermissionOverwrite(view_channel=is_public, connect=is_public, send_messages=False),
-                league_role: discord.PermissionOverwrite(view_channel=True, connect=True)
-            }
-            await combines_category.set_permissions(guild.default_role, view_channel=is_public, connect=is_public, send_messages=False)
-            await combines_category.set_permissions(league_role, view_channel=True, connect=True, send_messages=False)
-    
     async def _add_combines_category(self, ctx, name: str):
-        category = await self._combines_category(ctx.guild)
         # check if category exists already
-        if category:
-            await ctx.send("A category with the name \"{0}\" already exists".format(name))
-            return None
+        overwrites = {}
+        muted_role = self._get_role_by_name(ctx.guild, "Muted")
+        if muted_role:
+            overwrites[muted_role] = discord.PermissionOverwrite(connect=False)
         
         if not await self._is_public_combine(ctx.guild):
             league_role = self._get_role_by_name(ctx.guild, "League")
-            overwrites = {
-                ctx.guild.default_role: discord.PermissionOverwrite(view_channel=False, connect=False, send_messages=False),
-                league_role: discord.PermissionOverwrite(view_channel=True, connect=True, send_messages=False)
-            }
-        else:
-            overwrites=None
+            overwrites[ctx.guild.default_role] = discord.PermissionOverwrite(view_channel=False, connect=False, send_messages=False)
+            overwrites[league_role] = discord.PermissionOverwrite(view_channel=True, connect=True, send_messages=False)
 
-        category = await ctx.guild.create_category(name, overwrites=overwrites)
-        return category
+        return await ctx.guild.create_category(name, overwrites=overwrites)
 
-    async def _maybe_remove_combines_voice(self, guild: discord.Guild, voice_channel: discord.VoiceChannel):
-        tier = self._get_voice_tier(voice_channel)
-        category = await self._combines_category(guild)
-        tier_voice_channels = []
-        for vc in category.voice_channels:
-            if tier in vc.name:
-                tier_voice_channels.append(vc)
-        
-        # Never remove the last room for a tier
-        if len(tier_voice_channels) == 1:
-            return False
-
-        # Always retain room 1 for tier:
-        # await voice_channel.delete()
-        i = voice_channel.name.index("room ") + 5
-        # DISABLED: active players in room name
-        # j = voice_channel.name.index(" (")
-        room_num = int(voice_channel.name[i:]) # j])
-        room_one_empty = (room_num == 1)
-
-        # if voice_channel was not room 1
-        if not room_one_empty:
-            # No need to kick scouts. Let them hang out :)
-            if voice_channel.members:
+    async def _add_combines_voice(self, guild: discord.Guild, tier: str, category: discord.CategoryChannel=None):
+        if not category:
+            category = await self._get_tier_category(guild, tier)
+            if not category:
                 return False
-            await voice_channel.delete()
-            return True
-        
-        # delete the other empty room (instead of room 1)
-        for vc in tier_voice_channels:
-            if not vc.members and vc != voice_channel:
-                await vc.delete()
-                return True
-
-    async def _add_combines_info_channel(self, guild: discord.Guild, category: discord.CategoryChannel, name: str):
-        overwrites = {
-            guild.default_role: discord.PermissionOverwrite(send_messages=False)
-        }
-        tc = await category.create_text_channel(name, position=0, permissions_synced=True, overwrites=overwrites)
-
-        acronym = await self._get_acronym(guild)
-        info_message = await self._get_custom_message(guild)
-        if not info_message:
-            info_message = await self._get_default_message(ctx)
-        await tc.send(info_message)
-    
-    async def _add_combines_voice(self, guild: discord.Guild, category: discord.CategoryChannel, tier: str):
         # user_limit of 0 means there's no limit
         # determine position with same name +1
-        tier_rooms = []
-        for vc in category.voice_channels:
-            if tier in vc.name:
-                tier_rooms.append(vc)
-
-        room_makeable = False
-        new_position = None
+        new_position = 0
         new_room_number = 1
-        while not room_makeable:
-            room_makeable = True
-            for vc in tier_rooms:
-                i = vc.name.index("room ") + 5
-                # DISABLED: room count in name
-                # j = vc.name.index(" (")
-                vc_room_num = int(vc.name[i:])  # j])
-                if vc_room_num == new_room_number:
-                    new_room_number += 1
-                    new_position = vc.position
-                    room_makeable = False
-        
-        # DISABLED: room count in name
-        # ppr = await self._players_per_room(guild)
+        acronym = await self._get_acronym(guild)
         capacity = await self._room_capacity(guild)
-        # room_name = "{0} room {1} (0/{2})".format(tier, new_room_number, ppr)
-        room_name = "{0} room {1}".format(tier, new_room_number)
+        room_name = "{0} // {1}{2}".format(tier, acronym, new_room_number)
 
-        if not new_position:
-            await category.create_voice_channel(room_name, permissions_synced=True, user_limit=capacity)
-        else:
-            await category.create_voice_channel(room_name, permissions_synced=True, user_limit=capacity, position=new_position)
+        await category.create_voice_channel(room_name, permissions_synced=True, user_limit=capacity, position=new_position)
 
-    async def _member_joins_voice(self, member: discord.Member, voice_channel: discord.VoiceChannel):
-        combines_category = await self._combines_category(member.guild)
-        if voice_channel in (await self._combines_category(member.guild)).voice_channels:
-            player_count = await self._adjust_room_tally(member.guild, voice_channel)
-            if player_count == 1:
-                tier = self._get_voice_tier(voice_channel)
-                await self._add_combines_voice(member.guild, combines_category, tier)
-   
-    async def _member_leaves_voice(self, member: discord.Member, voice_channel: discord.VoiceChannel):
-        if voice_channel in (await self._combines_category(member.guild)).voice_channels:
-            # DISABLED
-            player_count = await self._adjust_room_tally(member.guild, voice_channel)
-            if player_count == 0:
-                await self._maybe_remove_combines_voice(member.guild, voice_channel)
-        
-    async def _get_category_by_name(self, guild: discord.Guild, name: str): 
-        for category in guild.categories:
-            if category.name == name:
-                return category
+    async def _get_tier_category(guild: discord.Guild, tier: str):
+        categories = await self._combines_categories(guild)
+        for tier_cat in categories:
+            if tier == tier_cat.name:
+                return tier_cat
         return None
-    
-    # DISABLED :/ (currently only returns player count)
-    async def _adjust_room_tally(self, guild: discord.Guild, voice_channel: discord.VoiceChannel):
-        # possibility: only call this function when an active player triggers the call and/or make this an increment/decrement function
-        fa_role = self._get_role_by_name(guild, "Free Agent")
-        de_role = self._get_role_by_name(guild, "Draft Eligible")
-        scout_role = self._get_role_by_name(guild, "Combine Scout")
-        player_count = 0
-        # max_size = await self._players_per_room(guild)
-        for member in voice_channel.members:
-            if not await self._is_public_combine(guild):
-                active_player = (fa_role in member.roles or de_role in member.roles) and scout_role not in member.roles
-            else:
-                active_player = scout_role not in member.roles
-            if active_player:
-                    player_count += 1
-        
-        # DISABLED: channel renaming
-        # name_base = voice_channel.name[:voice_channel.name.index(" (")]
-        # rename = "{0} ({1}/{2})".format(name_base, player_count, max_size)
-        # await voice_channel.edit(name=rename)
-        return player_count
 
     def _get_role_by_name(self, guild: discord.Guild, name: str):
         for role in guild.roles:
             if role.name == name:
                 return role
         return None
-    
-    def _get_voice_tier(self, voice_channel: discord.VoiceChannel):
-        return voice_channel.name.split()[0]
 
-    async def _combines_category(self, guild: discord.Guild):
-        saved_combine_cat = await self.config.guild(guild).combines_category()
-        for category in guild.categories:
-            if category.id == saved_combine_cat:
-                return category
-        return None
-    
-    async def _save_combine_category(self, guild: discord.Guild, category: discord.CategoryChannel):
-        await self.config.guild(guild).combines_category.set(category.id)
-    
-    # DISABLED: channel renaming
-    # async def _players_per_room(self, guild):
-    #     ppr = await self.config.guild(guild).players_per_room()
-    #     return ppr if ppr else None
-
-    async def _save_players_per_room(self, guild: discord.Guild, num_players: int):
-        await self.config.guild(guild).players_per_room.set(num_players)
-
+    async def _save_combines_categories(self, guild, categories: discord.CategoryChannel):
+        if categories:
+            return await self.config.guild(guild).Categories.set(categories)
+        return await self.config.guild(guild).Categories.set([])
+   
+    async def _combines_categories(self, guild):
+        return await self.config.guild(guild).Categories()
+   
     async def _room_capacity(self, guild):
         cap = await self.config.guild(guild).room_capacity()
         return cap if cap else 0
@@ -408,46 +130,3 @@ class CombineRooms(commands.Cog):
 
     async def _get_acronym(self, guild):
         return await self.config.guild(guild).acronym()
-
-    async def _set_custom_message(self, guild, message):
-        await self.config.guild(guild).CustomMessage.set(message)
-
-    async def _get_custom_message(self, guild):
-        return await self.config.guild(guild).CustomMessage()
-
-    async def _get_default_message(self, ctx):
-        acronym = await self._get_acronym(ctx.guild)
-        info_message = (
-            "Welcome to the {0} combines! Combine rooms will be available to all players who are Free Agents or Draft Eligible. "
-            "During combines, you are welcome to spend as much or as little time playing as you'd like. Your participation in combines "
-            "gives franchise scouts an opportunity to see how you play. No pressure though! The primary goal for combines is to give "
-            "everybody an opportunity to get introduced to gameplay at their respective tiers."
-
-            "\n\n__Server Information__"
-            "\nServers can be made by anybody in the combine room. We do ask that the lobbies are made with the following naming convention:"
-            "\n\n**Lobby Info:**"
-            "\n - Name: **<tier>**"
-            "\n - Password: **{1}<room number>**"
-            
-            "\n\n**Example:**"
-            "\n - Voice Channel Name: **Challenger room 4**"
-            "\n - Name: **Challenger**"
-            "\n - Password: **{1}4**"
-
-            "\n\n__The Role of Scouts__"
-            "\n - For lack of a better phrase, scouts are \"in charge\" of running combines."
-            "\n - If a scout requests a lineup, please respect this request."
-            "\n - If a scout requests for mutator settings such as adjusted time length, or a goal limit, please respect this request."
-            "\n - If you have concerns with how combines are being run, contact a mod or an admin."
-
-            "\n\n__Other Notes__"
-            "\n - Please try to curb your particpation in combines towards your own tier. Do not play outside of your tier without being requested "
-            "by a scout, or asking permission of the other players in the combine room."
-            "\n - Don't stress! All players have good and bad days. Scouts care more about _how you play_ than _how your perform_. If you have a "
-            "rough game, or a bad night, you'll have plenty of opportunity to show your abilities in remaining combine games"
-            "\n - As per {2} rules, do not be toxic or hostile towards other players."
-            "\n - GLHF!"
-        ).format(ctx.guild.name, acronym.lower(), acronym)
-        return info_message
-
-

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -117,6 +117,7 @@ class CombineRooms(commands.Cog):
         response = "Combines are now **{0}**.".format(public_str)
         await ctx.send(response)
 
+
     @commands.Cog.listener("on_voice_state_update")
     async def on_voice_state_update(self, member, before, after):
         # ignore when voice activity is within the same room

--- a/combineRooms/combineRooms.py
+++ b/combineRooms/combineRooms.py
@@ -3,7 +3,7 @@ from redbot.core import Config
 from redbot.core import commands
 from redbot.core import checks
 
-defaults = {"players_per_room": 6, "room_capacity": 10, "Categories": [], "public_combines": True, "acronym": "RSC", "CustomMessage": None}
+defaults = {"room_capacity": 10, "Categories": [], "public_combines": True, "acronym": "RSC"}
 
 
 class CombineRooms(commands.Cog):


### PR DESCRIPTION
Refactors all of `combineRooms` cog.

Improvements:
- Each tier has a dedicated category for combine channels
- Dynamic room management logic
    - New room made when a member is the first to join a room
    - All but first listed combines voice rooms removed when a member leaves an empty room (room 1 should always persist)
- Updated room information (i.e. combine publicity, acronym or voice channel user limit) will update currently existing rooms. A `<p><start/stop>Combines` cycle is no longer required for these changes to be applied.
- If a **Muted** role is established, they will not have permission to connect to any voice channels
- On voice activity, checks for before/after voice rooms before calling member join/leave functions. As a result, no errors should be logged when a member has voice activity to or from a disconnected state.

General Changes:
- Voice channel room format: `<tier> Room <number>` => `<tier> // <acronym><number>`

Removed:
- **combines-details** information channel and customization options.
- Behavior around **Draft Eligible**, **Free Agent**, and **Combine Scout** roles.
- Unused players-per-room code

Unchanged:
- Room growth - new rooms names will have the lowest number available above 0
- Acronym settings
- Room capacity settings
- Combine publicity (optionally public/private for "League" players)

resolves #98 