### PR TITLE
Adds standings behavior to match cog

### DIFF
--- a/match/README.md
+++ b/match/README.md
@@ -57,3 +57,12 @@ The `match` cog depends on the `teamManager` cog. Install `teamManager` before i
   - Examples:
     - `<p>addMatches "['1','September 10, 2018','Fire Ants','Leopards','octane','worst car']"`
     - `<p>addMatches "['1','September 10, 2018','Fire Ants','Leopards']" "['2','September 13, 2018','Leopards','Fire Ants']"`
+- `<p>setAPIKey <key>`
+  - Sets the authentication key for Google API requests. This is used to get standings information from the google sheets document.
+- `<p>setSheetId <id>`
+  - Sets the id of the google sheets document. This can be found from the Google Sheets url.
+  - Example: The ID can be found after "spreedsheet/d/"
+    - url: https://docs.google.com/spreadsheets/d/13VFcd35NtZLFySYR8UHTYcR0Jjc90OT6EdVhKuqZGBk/edit#gid=73973909
+    - Here, the ID is `13VFcd35NtZLFySYR8UHTYcR0Jjc90OT6EdVhKuqZGBk`
+- `<p>standings <tier>`
+  - Displays the standings for the provided Tier from the google sheets document. Franchise standings may be found if "franchise" is passed as the tier parameter.

--- a/match/README.md
+++ b/match/README.md
@@ -4,7 +4,7 @@ The `match` cog is primarily responsible for the creation and maintenance of lea
 
 ## Installation
 
-The `match` cog depends on the `teamManager` cog. Install `teamManager` before installing `match`.
+The `match` cog depends on the `teamManager` cog. Install `teamManager` before installing `match`. Note: Standings related commands uses the `requests` package. This must be installed to the virtual environment before running.
 
 ```
 <p>cog install RSCBot match

--- a/match/match.py
+++ b/match/match.py
@@ -222,6 +222,12 @@ class Match(commands.Cog):
         standings_data = await self._standings_data(ctx)
         api_key = standings_data['APIKey']
         sheet_id = standings_data['SheetId']
+
+        if not api_key or not sheet_id:
+            message = ":x: An admin must set an api key and a google sheets id to enable this command."
+            message += "\n\t\tUse `{p}help setAPIKey` or `{p}help setSheetId` for more information.".format(p=ctx.prefix)
+            await ctx.send(message)
+            return False
         
         # Determine teams per tier, request range
         starting_cell = "A2"
@@ -240,7 +246,12 @@ class Match(commands.Cog):
         standings = requests.get(url).json()
 
         # Parse, Read Data
-        header = standings['values'][0]
+        try:
+            header = standings['values'][0]
+        except:
+            await ctx.send(":x: {} is not a valid tier name.".format(tier))
+            return False
+        
         rank_i = header.index("Rank")
         wins_i = header.index("W")
         losses_i = header.index("L")

--- a/match/match.py
+++ b/match/match.py
@@ -216,7 +216,7 @@ class Match(commands.Cog):
     @commands.command()
     @commands.guild_only()
     async def standings(self, ctx, tier):
-        """Displays standings for any given tier"""
+        """Displays standings for a given tier"""
 
         # API Request Credentials
         standings_data = await self._standings_data(ctx)
@@ -248,7 +248,7 @@ class Match(commands.Cog):
         # Parse, Read Data
         try:
             header = standings['values'][0]
-        except:
+        except KeyError:
             await ctx.send(":x: {} is not a valid tier name.".format(tier))
             return False
         


### PR DESCRIPTION
Adds behavior for a `<p>standings <tier>` command.

`<p>setAPIKey <key>` and `<p>setSheetId` were added for this purpose. These must be set before the standings command will work.

Updates `match` readme