### PR TITLE
Six Mans updates

### DIFF
--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -713,6 +713,7 @@ class SixMans(commands.Cog):
 
         await ctx.channel.send(embed=embed)
 
+
     async def has_perms(self, ctx):
         helper_role = await self._helper_role(ctx)
         if ctx.author.guild_permissions.administrator:
@@ -815,7 +816,20 @@ class SixMans(commands.Cog):
         await self._save_players(ctx, _players)
         await self._save_games_played(ctx, _games_played)
 
+        if await self._get_automove(ctx): # game.automove not working?
+            qlobby_vc = await self._get_q_lobby_vc(ctx)
+            if qlobby_vc:
+                await self._move_to_voice(qlobby_vc, game.voiceChannels[0].members)
+                await self._move_to_voice(qlobby_vc, game.voiceChannels[1].members)
+
         await self._remove_game(ctx, game)
+
+    async def _move_to_voice(self, vc: discord.VoiceChannel, members):
+        for member in members:
+            try:
+                await member.move_to(vc)
+            except:
+                pass
 
     async def _remove_game(self, ctx, game):
         self.games.remove(game)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -185,14 +185,14 @@ class SixMans(commands.Cog):
         await ctx.send(embed=self._format_queue(ctx, six_mans_queue))
 
     @commands.guild_only()
-    @commands.command()
+    @commands.command(aliases=["setQueueLobby"])
     @checks.admin_or_permissions(manage_guild=True)
     async def setQLobby(self, ctx, lobby_voice: discord.VoiceChannel):
         await self._save_q_lobby_vc(ctx, lobby_voice.id)
         await ctx.send("Done")
     
     @commands.guild_only()
-    @commands.command()
+    @commands.command(aliases=["unsetQueueLobby, unsetQLobby"])
     @checks.admin_or_permissions(manage_guild=True)
     async def clearQLobby(self, ctx):
         await self._save_q_lobby_vc(ctx, None)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1034,6 +1034,7 @@ class SixMans(commands.Cog):
         automove = await self._get_automove(ctx)
         game = Game(players, text_channel, voice_channels, six_mans_queue.id, automove)
         await game.append_short_code_vc()
+        return game
 
     async def _create_game_channels(self, ctx, six_mans_queue):
         # sync permissions on channel creation, and edit overwrites (@everyone) immediately after

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1032,7 +1032,8 @@ class SixMans(commands.Cog):
             await text_channel.set_permissions(player, read_messages=True)
 
         automove = await self._get_automove(ctx)
-        return Game(players, text_channel, voice_channels, six_mans_queue.id, automove)
+        game = Game(players, text_channel, voice_channels, six_mans_queue.id, automove)
+        await game.append_short_code_vc()
 
     async def _create_game_channels(self, ctx, six_mans_queue):
         # sync permissions on channel creation, and edit overwrites (@everyone) immediately after
@@ -1246,6 +1247,10 @@ class Game:
         self.scoreReported = False
         self.automove = automove
 
+    async def append_short_code_vc(self):
+        for vc in self.voiceChannels:
+            await vc.edit(name="{} | {}".format(vc.name, str(self.id)[-3:]))
+
     async def add_to_blue(self, player):
         self.players.remove(player)
         self.blue.add(player)
@@ -1276,9 +1281,6 @@ class Game:
         self.captains = []
         self.captains.append(random.sample(list(self.blue), 1)[0])
         self.captains.append(random.sample(list(self.orange), 1)[0])
-
-    # def get_voice_channels(self):
-    #     return self.voiceChannels
 
     def __contains__(self, item):
         return item in self.players or item in self.orange or item in self.blue


### PR DESCRIPTION
- `<p>moveMe`  => moves members to their team vc if they have queued into a 6mans game
- `<p>setQLobby` => sets the 6mans general voice channel lobby
- `<p>unsetQLobby` => clears the 6mans general voice channel lobby (=`None`)
- if automove is enabled and a 6mans lobby vc has been set, all members connected to team vcs will be moved to the lobby vc after a successful score report
- if automove is not enabled, all members connected to team vcs will be moved to the lobby vc prior to the team vc channel deletion
- Updates how permissions are managed. upon text/voice creation, adds `permissions_synced=True` to sync with category
- Additional permissions (i.e. default role) are added immediately after channel creation
- permissions updated for helper role when any changes are made to the helper role or the 6mans category
- adds the last 3 characters of game.id to team voice channel names

Resolves #88 