### PR TITLE
Creates ModLink cog

### DIFF
--- a/modLink/README.md
+++ b/modLink/README.md
@@ -1,0 +1,43 @@
+# RSCBot: combineRooms
+
+The `combineRooms` cog is primarily responsible for managing combines for RSC. This involves dynamically creating and deleting voice channels under a "Combine Rooms" category. This cog uses discord events to keep rooms open for each tier that has been established.
+
+## Installation
+
+The `combineRooms` cog depends on the `teamManager` cog. Install `teamManager` as well as its dependencies before installing `combineRooms`.
+
+```
+<p>cog install RSCBot combineRooms
+<p>load combineRooms
+```
+
+## Usage
+
+- `<p>startCombines`
+  Creates a Combine Rooms channel category with all associated text and voice channels.
+
+- `<p>stopCombines`
+  Runs a teardown for all combine channels. This will remove all channels under the "Combine Rooms" categorty as well as the category itself.
+
+#### Roles involved:
+- League
+- Muted
+
+## Customization
+
+- `<p>setRoomCapacity` (Default: 10)
+  - Sets the limit for discord members in room.
+- `<p>togglePublicity` (Default: Public)
+  - Toggles the combines between a Public and Private status.
+  - If combines are Public, any member may participate.
+  - If combines are Private, only members with the "League" role may particpate.
+- `<p>setAcronym` (Default: RSC)
+  - Sets the acronym used in the combines cog.
+  - This is is relevant with the naming scheme for dynamically created voice channels.
+
+## Other commands
+
+The following commands can be used to check current properties of the server:
+- `<p>getRoomCapacity`
+- `<p>getCombinePublicity`
+- `<p>getAcronym`

--- a/modLink/README.md
+++ b/modLink/README.md
@@ -1,43 +1,34 @@
-# RSCBot: combineRooms
+# RSCBot: modLink
 
-The `combineRooms` cog is primarily responsible for managing combines for RSC. This involves dynamically creating and deleting voice channels under a "Combine Rooms" category. This cog uses discord events to keep rooms open for each tier that has been established.
+## About modLink
+
+The `modLink` cog is responsible for maintaining member status and representation consistency across multiple discord guilds. This cog processes member updates and applies them to each guild in the `modLink` network. This is defined by guilds the RSCBot is in, that have set an Event Log Channel.
+
+The following behaviors are shared across the guild network:
+
+- Shared role addition and removal (Default: ["Muted"])
+- Member bans and unbans.
+- Nickname changes
 
 ## Installation
 
-The `combineRooms` cog depends on the `teamManager` cog. Install `teamManager` as well as its dependencies before installing `combineRooms`.
+The `modLink` cog is independent from other RSCBot cogs.
 
 ```
-<p>cog install RSCBot combineRooms
-<p>load combineRooms
+<p>cog install RSCBot modLink
+<p>load modLink
 ```
 
-## Usage
+## Commands
 
-- `<p>startCombines`
-  Creates a Combine Rooms channel category with all associated text and voice channels.
+- `<p>setEventChannel [event_channel]`
 
-- `<p>stopCombines`
-  Runs a teardown for all combine channels. This will remove all channels under the "Combine Rooms" categorty as well as the category itself.
+  Sets the channel where all moderator-link related events are logged, and enables cross-guild member updates
 
-#### Roles involved:
-- League
-- Muted
+- `<p>unsetEventChannel`
 
-## Customization
+  Unsets the channel currently assigned as the event log channel and disables cross-guild member updates
 
-- `<p>setRoomCapacity` (Default: 10)
-  - Sets the limit for discord members in room.
-- `<p>togglePublicity` (Default: Public)
-  - Toggles the combines between a Public and Private status.
-  - If combines are Public, any member may participate.
-  - If combines are Private, only members with the "League" role may particpate.
-- `<p>setAcronym` (Default: RSC)
-  - Sets the acronym used in the combines cog.
-  - This is is relevant with the naming scheme for dynamically created voice channels.
+- `<p>getEventChannel`
 
-## Other commands
-
-The following commands can be used to check current properties of the server:
-- `<p>getRoomCapacity`
-- `<p>getCombinePublicity`
-- `<p>getAcronym`
+  Gets the channel currently assigned as the event log channel

--- a/modLink/__init__.py
+++ b/modLink/__init__.py
@@ -1,0 +1,4 @@
+from .combineRooms import CombineRooms
+
+def setup(bot):
+    bot.add_cog(CombineRooms(bot))

--- a/modLink/__init__.py
+++ b/modLink/__init__.py
@@ -1,4 +1,4 @@
-from .combineRooms import CombineRooms
+from .modLink import ModeratorLink
 
 def setup(bot):
-    bot.add_cog(CombineRooms(bot))
+    bot.add_cog(ModeratorLink(bot))

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -131,9 +131,7 @@ class ModeratorLink(commands.Cog):
         await event_log_channel.send("Done.")
 
     def _guild_member_from_id(self, guild, member_id):
-        for member in guild.members:
-            if member.id == member_id:
-                return member
+        return guild.get_member(member_id)
     
     def _guild_role_from_name(self, guild, role_name):
         for member in guild.roles:

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -1,0 +1,144 @@
+import discord
+from redbot.core import Config
+from redbot.core import commands
+from redbot.core import checks
+
+defaults = {"Guilds": [], "SharedRoles": ["Muted"], "EventLogChannel": None, "ActionLogChannel": None}
+
+
+class ModeratorLink(commands.Cog):
+    def __init__(self, bot):
+        self.config = Config.get_conf(self, identifier=1234567892, force_registration=True)
+        self.config.register_guild(**defaults)
+        self.bot = bot
+
+    @commands.guild_only()
+    @commands.command()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setEventChannel(self, ctx, event_channel: discord.TextChannel):
+        """Sets the channel where all moderator-link related events are logged, and enables cross-guild role sharing."""
+        await self._save_event_log_channel(ctx.guild, event_channel.id)
+        await ctx.send("Done")
+
+    @commands.guild_only()
+    @commands.command()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def unsetEventChannel(self, ctx):
+        """Gets the channel currently assigned as the event log channel"""
+        await self._save_event_log_channel(ctx.guild, None)
+        await ctx.send("Event log channel has been cleared.")
+
+    @commands.guild_only()
+    @commands.command()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def getEventChannel(self, ctx):
+        """Gets the channel currently assigned as the event log channel"""
+        try:
+            await ctx.send("Event log channel set to: {0}".format((await self._event_log_channel(ctx.guild)).mention))
+        except:
+            await ctx.send(":x: Event log channel not set")
+    
+
+    @bot.event
+    async def on_user_update(before, after):
+        if before.username != after.username:
+            pass
+        if before.discriminator != after.discriminator:
+            pass
+
+    @bot.event
+    async def on_member_update(before, after):
+        if before.roles != after.roles:
+            await self._process_role_update(before, after)
+        if before.nickname != after.nickname:
+            await self._process_nickname_change(before, after)
+            
+
+    @bot.event
+    async def on_member_ban(guild, user):
+        pass
+    
+    @bot.event
+    async def on_member_unban(guild, user):
+        pass
+
+
+    async def _process_role_update(self, before, after):
+        removed_roles = before.roles
+        added_roles = after.roles
+        for b_role in removed_roles:
+            if b_role in added_roles:
+                removed_roles.remove(b_role)
+                added_roles.remove(b_role)
+        
+        # member_instances = await self._shared_guild_member_instances(before.mutual_guilds, before)
+
+        # # this will try to add a role from one guild to another. TODO: get matching role from each guild as well.
+        shared_role_names = await self._get_shared_role_names(before.guild)
+        event_log_channel = await self._event_log_channel(before.guild)
+
+        if not event_log_channel:
+            return False
+
+        # Shared role removal
+        for role in removed_roles:
+            # for member in member_instances:
+            #     await member.remove_roles(role)
+            roles_to_remove = await self._shared_guild_role_instances(before.mutual_guilds, role.name) if role.name in shared_role_names else None
+            if roles_to_remove:
+                await after.remove_roles(*roles_to_remove)
+                await event_log_channel.send("Removed shared role across all shared servers ({}): {}".format(len(before.mutual_guilds), ', '.join(roles_to_remove)))
+        
+        # Shared role addition
+        for role in added_roles:
+            # for member in member_instances:
+            #     await member.add_roles(role)
+            roles_to_add = await self._shared_guild_role_instances(before.mutual_guilds, role.name) if role.name in shared_role_names else None
+            if roles_to_add:
+                await after.add_roles(*roles_to_add)
+                await event_log_channel.send("Added shared role across all shared servers ({}): {}".format(len(before.mutual_guilds), ', '.join(roles_to_add)))
+
+    # TODO: remove
+    async def _shared_guild_member_instances(self, mutual_guilds, target_member):
+        member_matches = []
+        for guild in mutual_guilds:
+            for member in guild.members:
+                if member.id == target_member.id:
+                    member_matches.append(member)
+                    if len(member_matches) == len(mutual_guilds):
+                        return member_matches
+        return member_matches
+    
+    async def _shared_guild_role_instances(self, mutual_guilds, target_role_name):
+        role_matches = []
+        for guild in mutual_guilds:
+            for role in guild.roles:
+                if role.name == target_role_name:
+                    role_matches.append(role)
+                    if len(role_matches) == len(mutual_guilds):
+                        return role_matches
+        return role_matches   
+
+    async def _process_nickname_update(self, before, after):
+        pass
+
+    async def _add_shared_role(self, guild, role_name: str):
+        roles = self._get_shared_roles(guild)
+        roles.append(role_name)
+        await self.config.guild(guild).Roles.set(roles)
+
+    async def _log_linked_event(self, source_guild, member, action: str):
+        for guild in self.bot.guilds:
+            event_log_channel = await self._event_log_channel()
+
+    async def _save_event_log_channel(self, guild, event_channel):
+        await self.config.guild(ctx.guild).TransChannel.set(event_channel)
+
+    async def _event_log_channel(self, guild):
+        await self.config.guild(guild).event_channel()
+
+    async def _save_shared_roles(self, guild, shared_role_names):
+        await self.config.guild(ctx.guild).SharedRoles.set(shared_roles)
+
+    async def _get_shared_role_names(self, guild):
+        return await self.config.guild(guild).SharedRoles()

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -42,6 +42,19 @@ class ModeratorLink(commands.Cog):
         except:
             await ctx.send(":x: Event log channel not set")
     
+    # @commands.guild_only()
+    # @commands.command()
+    # @checks.admin_or_permissions(manage_guild=True)
+    # async def ban(self, ctx, user: discord.User, *, reason=None):
+    #     await ctx.guild.ban(user, reason=reason, delete_message_days=0)
+    #     await ctx.send("Done.")
+    
+    # @commands.guild_only()
+    # @commands.command()
+    # @checks.admin_or_permissions(manage_guild=True)
+    # async def unban(self, ctx, user: discord.User, *, reason=None):
+    #     await ctx.guild.unban(user, reason=reason)
+    #     await ctx.send("Done.")
 
     @commands.Cog.listener("on_user_update")
     async def on_user_update(self, before, after):
@@ -74,21 +87,21 @@ class ModeratorLink(commands.Cog):
             
     @commands.Cog.listener("on_member_ban")
     async def on_member_ban(self, guild, user):
-        for linked_guild in self.guilds:
+        for linked_guild in self.bot.guilds:
             linked_guild_log = await self._event_log_channel(linked_guild)
-            is_banned = user in await linked_guild.bans()
+            is_banned = user in (banned_entry.user for banned_entry in await linked_guild.bans())
             if linked_guild_log and not is_banned:
-                await linked_guild.ban(user, reason="Banned from {}.".format(guild.name))
-                await linked_guild_log.send("{} (id: {}) has been banned. [initiated from **{}**]".format(user.name, user.id, guild.name))
+                await linked_guild.ban(user, reason="Banned from {}.".format(guild.name), delete_message_days=0)
+                await linked_guild_log.send("**{}** (id: {}) has been banned. [initiated from **{}**]".format(user.name, user.id, guild.name))
     
     @commands.Cog.listener("on_member_unban")
     async def on_member_unban(self, guild, user):
-        for linked_guild in self.guilds:
+        for linked_guild in self.bot.guilds:
             linked_guild_log = await self._event_log_channel(linked_guild)
-            is_banned = user in await linked_guild.bans()
+            is_banned = user in (banned_entry.user for banned_entry in await linked_guild.bans())
             if linked_guild_log and is_banned:
                 await linked_guild.unban(user, reason="Unbanned from {}.".format(guild.name))
-                await linked_guild_log.send("{} (id: {}) has been unbanned. [initiated from **{}**]".format(user.name, user.id, guild.name))
+                await linked_guild_log.send("**{}** (id: {}) has been unbanned. [initiated from **{}**]".format(user.mention, user.id, guild.name))
 
 
     async def _process_role_update(self, before, after):

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -194,6 +194,7 @@ class ModeratorLink(commands.Cog):
         for guild in mutual_guilds:
             member = self._guild_member_from_id(guild, before.id)
             name = member.nick if member.nick else member.name
+            channel = await self._event_log_channel(guild)
             
             try:
                 prefix = name[0:name.index(' | ')] if ' | ' in name else ''
@@ -205,7 +206,7 @@ class ModeratorLink(commands.Cog):
                         await member.edit(nick='{} | {}'.format(prefix, after_nick))
                     else:
                         await member.edit(nick=after_nick)
-                    await event_log_channel.send("{} has changed their name from **{}** to **{}** [initiated from **{}**]".format(member.mention, guild_before_name, after_nick, before.guild.name))
+                    await channel.send("{} has changed their name from **{}** to **{}** [initiated from **{}**]".format(member.mention, guild_before_name, after_nick, before.guild.name))
             except:
                 pass
 

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -3,7 +3,7 @@ from redbot.core import Config
 from redbot.core import commands
 from redbot.core import checks
 
-defaults = {"Guilds": [], "SharedRoles": ["Muted"], "EventLogChannel": None, "ActionLogChannel": None}
+defaults = {"Guilds": [], "SharedRoles": ["Muted"], "EventLogChannel": None}
 
 
 class ModeratorLink(commands.Cog):
@@ -72,7 +72,6 @@ class ModeratorLink(commands.Cog):
         if before_name != after_name:
             await self._process_nickname_update(before, after)
             
-
     @commands.Cog.listener("on_member_ban")
     async def on_member_ban(self, guild, user):
         for linked_guild in self.guilds:

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -39,14 +39,14 @@ class ModeratorLink(commands.Cog):
             await ctx.send(":x: Event log channel not set")
     
 
-    @bot.event
+    @commands.Cog.listener("on_user_update")
     async def on_user_update(before, after):
         if before.username != after.username:
             pass
         if before.discriminator != after.discriminator:
             pass
 
-    @bot.event
+    @commands.Cog.listener("on_member_update")
     async def on_member_update(before, after):
         if before.roles != after.roles:
             await self._process_role_update(before, after)
@@ -54,11 +54,11 @@ class ModeratorLink(commands.Cog):
             await self._process_nickname_change(before, after)
             
 
-    @bot.event
+    @commands.Cog.listener("on_member_ban")
     async def on_member_ban(guild, user):
         pass
     
-    @bot.event
+    @commands.Cog.listener("on_member_unban")
     async def on_member_unban(guild, user):
         pass
 

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -34,32 +34,36 @@ class ModeratorLink(commands.Cog):
     async def getEventChannel(self, ctx):
         """Gets the channel currently assigned as the event log channel"""
         try:
-            await ctx.send("Event log channel set to: {0}".format((await self._event_log_channel(ctx.guild)).mention))
+            channel = await self._event_log_channel(ctx.guild)
+            if channel:
+                await ctx.send("Event log channel set to: {0}".format((channel).mention))
+            else:
+                await ctx.send("PepeHands.")
         except:
             await ctx.send(":x: Event log channel not set")
     
 
     @commands.Cog.listener("on_user_update")
-    async def on_user_update(before, after):
+    async def on_user_update(self, before, after):
         if before.username != after.username:
             pass
         if before.discriminator != after.discriminator:
             pass
 
     @commands.Cog.listener("on_member_update")
-    async def on_member_update(before, after):
+    async def on_member_update(self, before, after):
         if before.roles != after.roles:
             await self._process_role_update(before, after)
-        if before.nickname != after.nickname:
-            await self._process_nickname_change(before, after)
+        # if before.nickname != after.nickname:
+        #     await self._process_nickname_change(before, after)
             
 
     @commands.Cog.listener("on_member_ban")
-    async def on_member_ban(guild, user):
+    async def on_member_ban(self, guild, user):
         pass
     
     @commands.Cog.listener("on_member_unban")
-    async def on_member_unban(guild, user):
+    async def on_member_unban(self, guild, user):
         pass
 
 
@@ -80,6 +84,8 @@ class ModeratorLink(commands.Cog):
         if not event_log_channel:
             return False
 
+        await event_log_channel("Here")
+
         # Shared role removal
         for role in removed_roles:
             # for member in member_instances:
@@ -97,6 +103,8 @@ class ModeratorLink(commands.Cog):
             if roles_to_add:
                 await after.add_roles(*roles_to_add)
                 await event_log_channel.send("Added shared role across all shared servers ({}): {}".format(len(before.mutual_guilds), ', '.join(roles_to_add)))
+        
+        await event_log_channel.send("Done.")
 
     # TODO: remove
     async def _shared_guild_member_instances(self, mutual_guilds, target_member):
@@ -132,13 +140,14 @@ class ModeratorLink(commands.Cog):
             event_log_channel = await self._event_log_channel()
 
     async def _save_event_log_channel(self, guild, event_channel):
-        await self.config.guild(ctx.guild).TransChannel.set(event_channel)
+        await self.config.guild(guild).EventLogChannel.set(event_channel)
+        # await self.config.guild(ctx.guild).TransChannel.set(trans_channel)
 
     async def _event_log_channel(self, guild):
-        await self.config.guild(guild).event_channel()
+        return guild.get_channel(await self.config.guild(guild).EventLogChannel())
 
     async def _save_shared_roles(self, guild, shared_role_names):
-        await self.config.guild(ctx.guild).SharedRoles.set(shared_roles)
+        await self.config.guild(guild).SharedRoles.set(shared_roles)
 
     async def _get_shared_role_names(self, guild):
         return await self.config.guild(guild).SharedRoles()

--- a/modLink/modLink.py
+++ b/modLink/modLink.py
@@ -141,8 +141,6 @@ class ModeratorLink(commands.Cog):
                     await guild_member.add_roles(guild_role)
                     channel = await self._event_log_channel(guild_member.guild)
                     await channel.send(role_assign_msg.format(guild_role.mention, guild_member.mention, before.guild.name))
-        
-        # await event_log_channel.send("Done.")
 
     def _guild_member_from_id(self, guild, member_id):
         return guild.get_member(member_id)


### PR DESCRIPTION
- When a guild in the network applied a shared role to one of their members, the bot applies the same role to them in all other guilds in the network.
- When a guild in the network removes a shared role to one of their members, the bot removes the same role from them in all other guilds in the network.
- When a member is banned or unbanned from a discord guild, the action is kept applied to all other guilds in the network.
- modLink behavior initiated from an external guild is logged to an event log channel.
- modLink doesn't do anything if a event log channel is not set.
- event log channel is not set by default.
- "Muted" is the only shared role by default.