### PR TITLE
Hideout Rooms Patch

### DIFF
--- a/dynamicRooms/README.md
+++ b/dynamicRooms/README.md
@@ -36,5 +36,9 @@ The `dynamicRooms` cog is independant from all other cogs. No prerequisites are 
   Disables hideout room behavior of all hideout categories.
 - `<p>getHideoutCategories`
   View all categories that are configured for hideout room management.
+- `<p>getHiddenRooms`
+  View all individiual voice channels that are actively hidden.
+- `<p>clearDynamicVCData`
+  Clears all dynamic room data in the `dynamicRooms` cog
 - `<p>toggleHideoutVCs`
   Enables or disables the `<p>hide command`.

--- a/dynamicRooms/dynamicRooms.py
+++ b/dynamicRooms/dynamicRooms.py
@@ -138,7 +138,7 @@ class DynamicRooms(commands.Cog):
             return await ctx.send(":x: There are currently no hiding rooms.")
         
         message = "The following rooms are currently hidden ({}):\n - ".format(len(hidden_vc_ids)) + "\n - ".join(self._get_channel_name(ctx.guild, vc) for vc in hidden_vc_ids)
-        await ctx.send("The following rooms are currently hidden ({}):\n - ".format(len(hidden_vc_ids)) + "\n - ".join(self._get_channel_name(ctx.guild, vc) for vc in hidden_vc_ids))
+        await ctx.send(message)
     
     @commands.command()
     @commands.guild_only()
@@ -247,9 +247,9 @@ class DynamicRooms(commands.Cog):
         
         # remove if dynamic or hideout room is empty
         dynamic_room = await self._is_dynamic_vc(voice_channel)
-        hiding_room = await self._is_hideout_vc(voice_channel)
+        hiding_room = await self._is_hiding(voice_channel)
         
-        if dynamic_room or hiding_rooms:
+        if dynamic_room or hiding_room:
             await voice_channel.delete()
 
 
@@ -273,7 +273,7 @@ class DynamicRooms(commands.Cog):
             return False
     
     async def _is_hiding(self, voice_channel: discord.VoiceChannel):
-        return vc.id in await self._get_hiding(vc.guild)
+        return voice_channel.id in await self._get_hiding(voice_channel.guild)
 
     async def _is_dynamic_vc(self, voice_channel: discord.VoiceChannel):
         guild = voice_channel.guild

--- a/dynamicRooms/dynamicRooms.py
+++ b/dynamicRooms/dynamicRooms.py
@@ -272,7 +272,6 @@ class DynamicRooms(commands.Cog):
         except:
             return False
     
-
     async def _is_hiding(self, voice_channel: discord.VoiceChannel):
         return vc.id in await self._get_hiding(vc.guild)
 

--- a/dynamicRooms/dynamicRooms.py
+++ b/dynamicRooms/dynamicRooms.py
@@ -179,7 +179,7 @@ class DynamicRooms(commands.Cog):
             await ctx.send("{}, you must be connected to a voice channel for that command to work.".format(member.mention))
             return
         
-        if not await self._is_hiding_vc(member.voice.channel):
+        if not await self._is_hideout_vc(member.voice.channel):
             await self._hide_vc(member.voice.channel)
     
     @commands.guild_only()
@@ -190,7 +190,7 @@ class DynamicRooms(commands.Cog):
             return
         vc = channel
         dynamic_vc = await self._is_dynamic_vc(vc)
-        hideout_vc = await self._is_hiding_vc(vc)
+        hideout_vc = await self._is_hideout_vc(vc)
         if not (dynamic_vc or hideout_vc):
             return
         
@@ -203,7 +203,6 @@ class DynamicRooms(commands.Cog):
         if vc.id in hidden_vcs:
             hidden_vcs.remove(vc.id)
             await self._save_hiding(vc.guild, hidden_vcs)
-        
         
 
     @commands.Cog.listener("on_voice_state_update")
@@ -223,7 +222,7 @@ class DynamicRooms(commands.Cog):
     
     async def _member_joins_voice(self, member: discord.Member, voice_channel: discord.VoiceChannel):
         dynamic_vc = await self._is_dynamic_vc(voice_channel)
-        hideout_vc = await self._is_hiding_vc(voice_channel)
+        hideout_vc = await self._is_hideout_vc(voice_channel)
         if not (dynamic_vc or hideout_vc):
             return False
         
@@ -248,7 +247,7 @@ class DynamicRooms(commands.Cog):
         
         # remove if dynamic or hideout room is empty
         dynamic_room = await self._is_dynamic_vc(voice_channel)
-        if not (dynamic_room or await self._is_hiding_vc(voice_channel)):
+        if not (dynamic_room or await self._is_hideout_vc(voice_channel)):
             return
 
         await voice_channel.delete()
@@ -266,7 +265,7 @@ class DynamicRooms(commands.Cog):
                 return "**{}** [{}]".format(channel.name, channel.id) 
         return None
 
-    async def _is_hiding_vc(self, voice_channel: discord.VoiceChannel):
+    async def _is_hideout_vc(self, voice_channel: discord.VoiceChannel):
         # guild = voice_channel.guild
         # hideout_categories = await self._get_hideout_categories(voice_channel.guild)
         hiding_vcs = await self._get_hiding(voice_channel.guild)

--- a/dynamicRooms/dynamicRooms.py
+++ b/dynamicRooms/dynamicRooms.py
@@ -181,8 +181,6 @@ class DynamicRooms(commands.Cog):
         
         if not await self._is_hiding_vc(member.voice.channel):
             await self._hide_vc(member.voice.channel)
-        else:
-            await member.voice.channel.edit(name='no')
     
     @commands.guild_only()
     @commands.Cog.listener("on_guild_channel_delete")

--- a/dynamicRooms/dynamicRooms.py
+++ b/dynamicRooms/dynamicRooms.py
@@ -193,7 +193,7 @@ class DynamicRooms(commands.Cog):
                     dynamic_vcs.append(clone_vc.id)
                     await self._save_dynamic_rooms(member.guild, dynamic_vcs)
 
-        if hideout_vc and len(voice_channel.members) >= voice_channel.user_limit:
+        if hideout_vc and (not await self._is_hiding(voice_channel)) and len(voice_channel.members) == voice_channel.user_limit:
             await self._hide_vc(voice_channel)
 
     async def _member_leaves_voice(self, member: discord.Member, voice_channel: discord.VoiceChannel):
@@ -303,6 +303,9 @@ class DynamicRooms(commands.Cog):
     # Rooms that hide upon command (<p>hide) => maybe merge with hideout rooms
     async def _save_hiding(self, guild, hidden_rooms):
         await self.config.guild(guild).Hiding.set(hidden_rooms)
+
+    async def _is_hiding(self, vc: VoiceChannel):
+        return vc.id in await self._get_hiding(vc.guild)
 
     async def _get_hiding(self, guild):
         return await self.config.guild(guild).Hiding()


### PR DESCRIPTION
Refactors `dynamicRooms`
- When dynamic or hidden room is left empty, the channel is deleted on_member_leave
- When a dynamic channel is deleted, it is removed from the bot's dynamic/hidden vc data as appropriate. 
  - If a dynamic vc is manually deleted, it will not cause errors with debugging commands, or potential other events. All-in-all, we correctly dispose of data
- member join/leave events will not forcibly re-hide hiding channels.
- Hideout categories only hide when someone joins and the occupancy is equal to the capacity
- Readme is updated