### PR TITLE
First Iteration of bcManager

### DIFF
--- a/bcManager/BCManager.py
+++ b/bcManager/BCManager.py
@@ -757,7 +757,8 @@ class BCManager(commands.Cog):
                 players.append(player)
         return players
 
-    # json db
+# json db
+
     async def _get_auth_token(self, guild):
         return await self.config.guild(guild).AuthToken()
     

--- a/bcManager/BCManager.py
+++ b/bcManager/BCManager.py
@@ -39,6 +39,7 @@ class BCManager(commands.Cog):
         """Finds match games from recent public uploads, and adds them to the correct Ballchasing subgroup
         """
 
+        # TODO: do not allow players to report replays for teams they are not a part of (unless admin or GM)
         # Get match information
         member = ctx.message.author
         match = await self.get_match(ctx, member, team_name, match_day)

--- a/bcManager/BCManager.py
+++ b/bcManager/BCManager.py
@@ -1,0 +1,788 @@
+from .config import config
+import requests
+import tempfile
+import os
+import json
+import discord
+import asyncio
+
+from redbot.core import Config
+from redbot.core import commands
+from redbot.core import checks
+from redbot.core.utils.predicates import ReactionPredicate
+from redbot.core.utils.menus import start_adding_reactions
+from datetime import datetime, timezone
+
+
+defaults = {
+    "AuthToken": config.auth_token,
+    "TopLevelGroup": config.top_level_group,
+    "TierRank": config.tier_rank,
+    "ReplayDumpChannel": None
+}
+global_defaults = {"AccountRegister": {}}
+verify_timeout = 30
+
+class BCManager(commands.Cog):
+    """Manages aspects of Ballchasing Integrations with RSC"""
+
+    def __init__(self, bot):
+        self.config = Config.get_conf(self, identifier=1234567893, force_registration=True)
+        self.config.register_guild(**defaults)
+        self.config.register_global(**global_defaults)
+        self.team_manager_cog = bot.get_cog("TeamManager")
+        self.match_cog = bot.get_cog("Match")
+    
+    @commands.command(aliases=['bcr', 'bcpull'])
+    @commands.guild_only()
+    async def bcreport(self, ctx, team_name=None, match_day=None):
+        """
+        Finds match games from recent public uploads, and adds them to the correct Ballchasing subgroup
+        """
+
+        # Get match information
+        member = ctx.message.author
+        match = await self.get_match(ctx, member, team_name, match_day)
+
+        if not match:
+            await ctx.send(":x: No match found.")
+            return False
+
+        # Get team/tier information
+        match_day = match['matchDay']
+        franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, match['home'])
+        emoji_url = ctx.guild.icon_url
+
+        embed = discord.Embed(
+            title="Match Day {}: {} vs {}".format(match_day, match['home'], match['away']),
+            description="Searching https://ballchasing.com for publicly uploaded replays of this match...",
+            color=tier_role.color
+        )
+        if emoji_url:
+            embed.set_thumbnail(url=emoji_url)
+        bc_status_msg = await ctx.send(embed=embed)
+        
+
+        # Find replays from ballchasing
+        replays_found = await self._find_match_replays(ctx, member, match)
+
+        ## Not found:
+        if not replays_found:
+            embed.description = ":x: No matching replays found on ballchasing."
+            await bc_status_msg.edit(embed=embed)
+            return False
+        
+        ## Found:
+        replay_ids, summary, winner = replays_found
+        
+        if winner:
+            franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, winner)
+            emoji = await self.team_manager_cog._get_franchise_emoji(ctx, franchise_role)
+            emoji_url = emoji.url
+        
+
+        # Prepare embed edits for score confirmation
+        prompt_embed = discord.Embed.from_dict(embed.to_dict())
+        prompt_embed.description = "Match summary:\n{}".format(summary)
+        prompt_embed.set_thumbnail(url=emoji_url)
+        prompt_embed.description += "\n\nPlease react to confirm the score summary for this match."
+
+        success_embed = discord.Embed.from_dict(prompt_embed.to_dict())
+        success_embed.description = "Match summary:\n{}".format(summary)
+        success_embed.description += "\n\n:signal_strength: Results confirmed. Creating a ballchasing replay group. This may take a few seconds..." # "\U0001F4F6"
+
+        reject_embed = discord.Embed.from_dict(prompt_embed.to_dict())
+        reject_embed.description = "Match summary:\n{}".format(summary)
+        reject_embed.description += "\n\n:x: Ballchasing upload has been cancelled."
+        
+        if not await self._embed_react_prompt(ctx, prompt_embed, existing_message=bc_status_msg, success_embed=success_embed, reject_embed=reject_embed):
+            return False
+        
+        # Find or create ballchasing subgroup
+        match_subgroup_id = await self._get_replay_destination(ctx, match)
+
+        # Download and upload replays
+        tmp_replay_files = await self._download_replays(ctx, replay_ids)
+        uploaded_ids = await self._upload_replays(ctx, match_subgroup_id, tmp_replay_files)
+        # await ctx.send("replays in subgroup: {}".format(", ".join(uploaded_ids)))
+        
+        renamed = await self._rename_replays(ctx, uploaded_ids)
+
+        embed.description = "Match summary:\n{}\n\nView the ballchasing group: https://ballchasing.com/group/{}\n\n:white_check_mark: Done".format(summary, match_subgroup_id)
+        embed.set_thumbnail(url=emoji_url)
+        await bc_status_msg.edit(embed=embed)
+        
+    @commands.command(aliases=['setAuthKey'])
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setAuthToken(self, ctx, auth_token):
+        """
+        Sets the Auth Key for Ballchasing API requests.
+        Note: Auth Token must be generated from the Ballchasing group owner
+        """
+        token_set = await self._save_auth_token(ctx, auth_token)
+        if(token_set):
+            await ctx.send("Done.")
+        else:
+            await ctx.send(":x: Error setting auth token.")
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setTierRank(self, ctx, tier, rank):
+        tiers = await self.team_manager_cog.tiers(ctx)
+        tier_found = False
+        for t in tiers:
+            if t.lower() == tier.lower():
+                tier_found = True
+                break
+        
+        old_rank = None
+        tier_ranks = await self._get_tier_ranks(ctx)
+        if tier in tier_ranks:
+            old_rank = tier_ranks['tier']
+        
+        if old_rank != rank:
+            await ctx.send("The **{}** rank was changed from {} to {}".format(tier=tier.Title(), old_rank=old_rank, new_rank=rank))
+        else:
+            await ctx.send("Done")
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setTopLevelGroup(self, ctx, top_level_group):
+        """
+        Sets the Top Level Ballchasing Replay group for saving match replays.
+        Note: Auth Token must be generated from the Ballchasing group owner
+        """
+        group_set = await self._save_top_level_group(ctx, top_level_group)
+        if(group_set):
+            await ctx.send("Done.")
+        else:
+            await ctx.send(":x: Error setting top level group.")
+    
+    @commands.command(aliases=['bcGroup', 'ballchasingGroup', 'bcg'])
+    @commands.guild_only()
+    async def bcgroup(self, ctx):
+        group_code = await self._get_top_level_group(ctx)
+        url = "https://ballchasing.com/group/{}".format(group_code)
+        if group_code:
+            await ctx.send("See all season replays in the top level ballchasing group: {}".format())
+        else:
+            await ctx.send(":x: A ballchasing group has not been set for this season yet.")
+
+    @commands.command(aliases=['accountRegister', 'addAccount'])
+    @commands.guild_only()
+    async def registerAccount(self, ctx, platform, identifier):
+        """Allows user to register account for ballchasing requests. This may be found by searching your appearances on ballchasing.com
+        Examples:
+            [p]registerAccount steam 76561199096013422
+            [p]registerAccount xbox e4b17b0000000900
+            [p]registerAccount ps4 touchetupac2
+            [p]registerAccount epic 76edd61bd58841028a8ee27373ae307a
+        """
+
+        # Check platform
+        if platform.lower() not in ['steam', 'xbox', 'ps4', 'ps5', 'epic']:
+            await ctx.send(":x: \"{}\" is an invalid platform".format(platform))
+            return False
+
+        # Validate account -- check for public ballchasing appearances
+        valid_account = await self._validate_account(ctx, platform, identifier)
+        if valid_account:
+            username, appearances = valid_account
+        else:
+            await ctx.send(":x: No ballchasing replays found for user: {identifier} ({platform}) ".format(identifier=identifier, platform=platform))
+            return False
+
+        # React to confirm account registration
+        if str(appearances) == "10000":
+            appearances = "{}+".format(appearances)
+        prompt = "**{username}** ({platform}) appears in **{count}** ballchasing replays.".format(username=username, platform=platform, count=appearances)
+        prompt += "\n\nWould you like to register this account?"
+        nvm_message = "Registration cancelled."
+        if not await self._react_prompt(ctx, prompt, nvm_message):
+            return False
+        
+        account_register = await self._get_account_register()
+        pid = str(ctx.message.author.id)
+        if pid in account_register:
+            account_register[pid].append([platform, identifier])
+        else:
+            account_register[pid] = [[platform, identifier]]
+
+        # Register account
+        await self._save_account_register(account_register)
+        await ctx.send("Done")
+    
+    @commands.command(aliases=['rmaccount', 'removeAccount'])
+    @commands.guild_only()
+    async def unregisterAccount(self, ctx, platform, identifier=None):
+        remove_accs = []
+        account_register = await self._get_account_register()
+        member = ctx.message.author
+        if str(member.id) in account_register:
+            for account in account_register[str(member.id)]:
+                if account[0] == platform:
+                    if not identifier or account[1] == identifier:
+                        remove_accs.append(account)
+        
+        if not remove_accs:
+            await ctx.send(":x: No matching account has been found.")
+            return False
+        
+        prompt = "React to confirm removal of the following account(s):\n - " + "\n - ".join("{}: {}".format(acc[0], acc[1]) for acc in remove_accs)
+        if not await self._react_prompt(ctx, prompt, "No accounts have been removed."):
+            return False
+        
+        count = 0
+        for acc in remove_accs:
+            account_register[str(member.id)].remove(acc)
+            count += 1
+        
+        await self._save_account_register(account_register)
+        await ctx.send(":white_check_mark: Removed **{}** account(s).".format(count))
+
+    @commands.command(aliases=['rmaccounts', 'clearaccounts', 'clearAccounts'])
+    @commands.guild_only()
+    async def unregisterAccounts(self, ctx):
+        """Unlinks registered account for ballchasing requests."""
+        account_register = await self._get_account_register(ctx.guild)
+        discord_id = str(ctx.message.author.id)
+        if discord_id in account_register:
+            count = len(account_register[discord_id])
+            accounts = await self._get_all_accounts(ctx, ctx.message.author)
+            prompt = "React to confirm removal of the following accounts ({}):\n - ".format(len(accounts)) + "\n - ".join("{}: {}".format(acc[0], acc[1]) for acc in accounts)
+            if not await self._react_prompt(ctx, prompt, "No accounts have been removed."):
+                return False
+            
+            del account_register[discord_id]
+            await ctx.send(":white_check_mark: Removed **{}** account(s).".format(count))
+        else:
+            await ctx.send("No account found.")
+
+    @commands.command(aliases=['accs', 'myAccounts', 'registeredAccounts'])
+    @commands.guild_only()
+    async def accounts(self, ctx):
+        """view all accounts that have been registered to with your discord account in this guild."""
+        member = ctx.message.author
+        accounts = await self._get_member_accounts(member)
+        if not accounts:
+            await ctx.send("{}, you have not registered any accounts.".format(member.mention))
+            return
+
+        show_accounts = "{}, you have registered the following accounts:\n - ".format(member.mention) + "\n - ".join("{}: {}".format(acc[0], acc[1]) for acc in accounts)
+        await ctx.send(show_accounts)
+
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def massAddAccounts(self, ctx):
+        pass
+    
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def clearAccountData(self, ctx):
+        pass
+
+
+    # @commands.Cog.listener("on_message")
+    # async def on_message(self, message):
+    #     member = message.author
+
+
+
+    async def _bc_get_request(self, ctx, endpoint, params=[], auth_token=None):
+        if not auth_token:
+            auth_token = await self._get_auth_token(ctx.guild)
+        
+        url = 'https://ballchasing.com/api'
+        url += endpoint
+        params = '&'.join(params)
+        if params:
+            url += "?{}".format(params)
+        
+        return requests.get(url, headers={'Authorization': auth_token})
+
+    async def _bc_post_request(self, ctx, endpoint, params=[], auth_token=None, json=None, data=None, files=None):
+        if not auth_token:
+            auth_token = await self._get_auth_token(ctx.guild)
+        
+        url = 'https://ballchasing.com/api'
+        url += endpoint
+        params = '&'.join(params)
+        if params:
+            url += "?{}".format(params)
+        
+        return requests.post(url, headers={'Authorization': auth_token}, json=json, data=data, files=files)
+
+    async def _bc_patch_request(self, ctx, endpoint, params=[], auth_token=None, json=None, data=None):
+        if not auth_token:
+            auth_token = await self._get_auth_token(ctx.guild)
+
+        url = 'https://ballchasing.com/api'
+        url += endpoint
+        params = '&'.join(params)
+        if params:
+            url += "?{}".format(params)
+        
+        return requests.patch(url, headers={'Authorization': auth_token}, json=json, data=data)
+
+    async def _react_prompt(self, ctx, prompt, if_not_msg=None, embed:discord.Embed=None):
+        user = ctx.message.author
+        if embed:
+            embed.description = prompt
+            react_msg = await ctx.send(embed=embed)
+        else:
+            react_msg = await ctx.send(prompt)
+        start_adding_reactions(react_msg, ReactionPredicate.YES_OR_NO_EMOJIS)
+        try:
+            pred = ReactionPredicate.yes_or_no(react_msg, user)
+            await ctx.bot.wait_for("reaction_add", check=pred, timeout=verify_timeout)
+            if pred.result:
+                return True
+            if if_not_msg:
+                await ctx.send(if_not_msg)
+            return False
+        except asyncio.TimeoutError:
+            await ctx.send("Sorry {}, you didn't react quick enough. Please try again.".format(user.mention))
+            return False
+
+    async def _embed_react_prompt(self, ctx, embed, existing_message=None, success_embed=None, reject_embed=None, clear_after_confirm=True):
+        user = ctx.message.author
+        if existing_message:
+            react_msg = existing_message
+            await react_msg.edit(embed=embed)
+        else:
+            react_msg = await ctx.send(embed=embed)
+        
+        start_adding_reactions(react_msg, ReactionPredicate.YES_OR_NO_EMOJIS)
+        try:
+            pred = ReactionPredicate.yes_or_no(react_msg, user)
+            await ctx.bot.wait_for("reaction_add", check=pred, timeout=verify_timeout)
+            if pred.result:
+                await react_msg.edit(embed=success_embed)
+                if clear_after_confirm:
+                    await react_msg.clear_reactions()
+                return True
+            if reject_embed:
+                await react_msg.edit(embed=reject_embed)
+            return False
+        except asyncio.TimeoutError:
+            await react_msg.edit(embed=reject_embed)
+            await ctx.send("Sorry {}, you didn't react quick enough. Please try again.".format(user.mention))
+            return False
+
+    async def _get_steam_ids(self, guild, discord_id):
+        discord_id = str(discord_id)
+        steam_accounts = []
+        account_register = await self._get_account_register()
+        if discord_id in account_register:
+            for account in account_register[discord_id]:
+                if account[0] == 'steam':
+                    steam_accounts.append(account[1])
+        return steam_accounts
+    
+    async def _get_member_accounts(self, member):
+        accs = []
+        account_register = await self._get_account_register()
+        discord_id = str(member.id)
+        if discord_id in account_register:
+            for account in account_register[discord_id]:
+                accs.append(account)
+        return accs
+    
+    async def _validate_account(self, ctx, platform, identifier):
+        auth_token = config.auth_token
+        endpoint = '/replays'
+        params = [
+            'player-id={platform}:{identifier}'.format(platform=platform, identifier=identifier),
+            'count=1'
+        ]
+        r = await self._bc_get_request(ctx, endpoint, params)
+        data = r.json()
+
+        appearances = 0
+        username = None
+        if data['list']:
+            for team_color in ['blue', 'orange']:
+                for player in data['list'][0][team_color]['players']:
+                    if player['id']['platform'] == platform and player['id']['id'] == identifier:
+                        username = player['name']
+                        appearances = data['count']
+                        break
+        if username:
+            return username, appearances
+        return False
+
+    def get_replay_teams(self, replay):
+        try:
+            blue_name = replay['blue']['name'].title()
+        except:
+            blue_name = "Blue"
+        try:
+            orange_name = replay['orange']['name'].title()
+        except:
+            orange_name = "Orange"
+
+        blue_players = []
+        for player in replay['blue']['players']:
+            blue_players.append(player['name'])
+        
+        orange_players = []
+        for player in replay['orange']['players']:
+            orange_players.append(player['name'])
+        
+        teams = {
+            'blue': {
+                'name': blue_name,
+                'players': blue_players
+            },
+            'orange': {
+                'name': orange_name,
+                'players': orange_players
+            }
+        }
+        return teams
+
+    async def _get_steam_id_from_token(self, ctx, auth_token=None):
+        if not auth_token:
+            auth_token = await self._get_auth_token(ctx.guild)
+        r = await self._bc_get_request(ctx, "")
+        if r.status_code == 200:
+            return r.json()['steam_id']
+        return None
+
+    def get_player_id(discord_id):
+        arr = config.account_register[discord_id]
+        player_id = "{}:{}".format(arr[0], arr[1])
+        return player_id
+
+    async def _get_uploader_id(self, ctx, discord_id):
+        account_register = await self._get_account_register()
+        if ctx.member.id in account_register:
+            if account_register[discord_id][0] != 'steam':
+                return account_register[discord_id][1]
+        return None
+
+    def is_full_replay(self, replay_data):
+        if replay_data['duration'] < 300:
+            return False
+        
+        blue_goals = replay_data['blue']['goals'] if 'goals' in replay_data['blue'] else 0
+        orange_goals = replay_data['orange']['goals'] if 'goals' in replay_data['orange'] else 0
+        if blue_goals == orange_goals:
+            return False
+        for team in ['blue', 'orange']:
+            for player in replay_data[team]['players']:
+                if player['start_time'] == 0:
+                    return True
+        return False
+
+    def is_match_replay(self, match, replay_data):
+        match_day = match['matchDay']   # match cog
+        home_team = match['home']       # match cog
+        away_team = match['away']       # match cog
+
+        if not self.is_full_replay(replay_data):
+            return False
+
+        replay_teams = self.get_replay_teams(replay_data)
+
+        home_team_found = replay_teams['blue']['name'].lower() in home_team.lower() or replay_teams['orange']['name'].lower() in home_team.lower()
+        away_team_found = replay_teams['blue']['name'].lower() in away_team.lower() or replay_teams['orange']['name'].lower() in away_team.lower()
+
+        return home_team_found and away_team_found
+
+    async def get_match(self, ctx, member, team=None, match_day=None):
+        if not match_day:
+            match_day = await self.match_cog._match_day(ctx)
+        if not team:
+            team = (await self.team_manager_cog.teams_for_user(ctx, member))[0]
+        
+        match = await self.match_cog.get_match_from_day_team(ctx, match_day, team)
+        return match
+
+    async def _get_replay_destination(self, ctx, match, top_level_group=None, group_owner_discord_id=None):
+        
+        auth_token = await self._get_auth_token(ctx.guild)
+
+        # needs both to override default -- TODO: Remove non-match params (derive logically)
+        if not group_owner_discord_id or not top_level_group:
+            bc_group_owner = await self._get_steam_id_from_token(ctx, auth_token)
+            top_level_group = await self._get_top_level_group(ctx)
+        else:
+            bc_group_owner = await self._get_uploader_id(ctx, group_owner_discord_id)  # config.group_owner_discord_id
+
+        # RSC/<top level group>/<tier num><tier>/Match Day <match day>/<Home> vs <Away>
+        tier = (await self.team_manager_cog._roles_for_team(ctx, match['home']))[1].name  # Get tier role's name
+        tier_group = await self._get_tier_subgroup_name(ctx, tier)
+        ordered_subgroups = [
+            tier_group,
+            "Match Day {}".format(str(match['matchDay']).zfill(2)),
+            "{home} vs {away}".format(home=match['home'].title(), away=match['away'].title())
+        ]
+
+        endpoint = '/groups'
+        
+        params = [
+            # 'player-id={}'.format(bcc_acc_rsc),
+            'creator={}'.format(bc_group_owner),
+            'group={}'.format(top_level_group)
+        ]
+
+        r = await self._bc_get_request(ctx, endpoint, params, auth_token)
+        data = r.json()
+
+        # Dynamically create sub-group
+        current_subgroup_id = top_level_group
+        next_subgroup_id = None
+        for next_group_name in ordered_subgroups:
+            if next_subgroup_id:
+                current_subgroup_id = next_subgroup_id
+            next_subgroup_id = None 
+
+            # Check if next subgroup exists
+            if 'list' in data:
+                for data_subgroup in data['list']:
+                    if data_subgroup['name'] == next_group_name:
+                        next_subgroup_id = data_subgroup['id']
+                        break
+            
+            # Prepare & Execute  Next request:
+            # ## Next subgroup found: request its contents
+            if next_subgroup_id:
+                params = [
+                    'creator={}'.format(bc_group_owner),
+                    'group={}'.format(next_subgroup_id)
+                ]
+
+                r = await self._bc_get_request(ctx, endpoint, params, auth_token)
+                data = r.json()
+
+            # ## Creating next sub-group
+            else:
+                payload = {
+                    'name': next_group_name,
+                    'parent': current_subgroup_id,
+                    'player_identification': config.player_identification,
+                    'team_identification': config.team_identification
+                }
+                r = await self._bc_post_request(ctx, endpoint, auth_token=auth_token, json=payload)
+                data = r.json()
+                
+                try:
+                    next_subgroup_id = data['id']
+                except:
+                    await ctx.send(":x: Error creating Ballchasing group: {}".format(next_group_name))
+                    return False
+            
+        return next_subgroup_id
+
+    async def _find_match_replays(self, ctx, member, match):
+
+        # search for appearances in private matches
+        endpoint = "/replays"
+        sort = 'replay-date' # 'created
+        sort_dir = 'desc' # 'asc'
+        count = config.search_count
+
+        # RFC3339 Date/Time format
+        now = datetime.now(timezone.utc).astimezone().isoformat()
+        adj_char = '+' if '+' in str(now) else '-'
+        zone_adj = "{}{}".format(adj_char, str(now).split(adj_char)[-1])
+
+        date_string = match['matchDate']
+        match_date = datetime.strptime(date_string, '%B %d, %Y').strftime('%Y-%m-%d')
+        start_match_date_rfc3339 = "{}T00:00:00{}".format(match_date, zone_adj)
+        end_match_date_rfc3339 = "{}T23:59:59{}".format(match_date, zone_adj)
+
+        params = [
+            # 'uploader={}'.format(uploader),
+            'playlist=private',
+            # 'replay-date-after={}'.format(start_match_date_rfc3339),  # Filters by matches played on this day
+            # 'replay-date-before={}'.format(end_match_date_rfc3339),
+            'count={}'.format(count),
+            'sort-by={}'.format(sort),
+            'sort-dir={}'.format(sort_dir)
+        ]
+
+        auth_token = await self._get_auth_token(ctx.guild)
+        for player in await self._get_all_match_players(ctx, match):
+            for steam_id in await self._get_steam_ids(ctx.guild, player.id):
+                uploaded_by_param='uploader={}'.format(steam_id)
+                params.append(uploaded_by_param)
+
+                r = await self._bc_get_request(ctx, endpoint, params=params, auth_token=auth_token)
+                data = r.json()
+                params.remove(uploaded_by_param)
+
+                # checks for correct replays
+                home_wins = 0
+                away_wins = 0
+                replay_ids = []
+                for replay in data['list']:
+                    if self.is_match_replay(match, replay):
+                        replay_ids.append(replay['id'])
+                        if replay['blue']['name'].lower() in match['home'].lower():
+                            home = 'blue'
+                            away = 'orange'
+                        else:
+                            home = 'orange'
+                            away = 'blue'
+                        
+                        home_goals = replay[home]['goals'] if 'goals' in replay[home] else 0
+                        away_goals = replay[away]['goals'] if 'goals' in replay[away] else 0
+                        if home_goals > away_goals:
+                            home_wins += 1
+                        else:
+                            away_wins += 1
+
+                series_summary = "**{home_team}** {home_wins} - {away_wins} **{away_team}**".format(
+                    home_team = match['home'],
+                    home_wins = home_wins,
+                    away_wins = away_wins,
+                    away_team = match['away']
+                )
+                winner = None
+                if home_wins > away_wins:
+                    winner = match['home']
+                elif home_wins < away_wins:
+                    winner = match['away']
+
+                if replay_ids:
+                    return replay_ids, series_summary, winner
+        return None
+    
+    async def _download_replays(self, ctx, replay_ids):
+        auth_token = await self._get_auth_token(ctx.guild)
+        tmp_replay_files = []
+        this_game = 1
+        for replay_id in replay_ids[::-1]:
+            endpoint = "/replays/{}/file".format(replay_id)
+            r = await self._bc_get_request(ctx, endpoint, auth_token=auth_token)
+            
+            # replay_filename = "Game {}.replay".format(this_game)
+            replay_filename = "{}.replay".format(replay_id)
+            
+            tf = tempfile.NamedTemporaryFile()
+            tf.name += ".replay"
+            tf.write(r.content)
+            tmp_replay_files.append(tf)
+            this_game += 1
+
+        return tmp_replay_files
+
+    async def _upload_replays(self, ctx, subgroup_id, files_to_upload):
+        endpoint = "/v2/upload"
+        params = [
+            'visibility={}'.format(config.visibility),
+            'group={}'.format(subgroup_id)
+        ]
+        auth_token = await self._get_auth_token(ctx.guild)
+
+        replay_ids_in_group = []
+        for replay_file in files_to_upload:
+            replay_file.seek(0)
+            files = {'file': replay_file}
+
+            r = await self._bc_post_request(ctx, endpoint, params, auth_token=auth_token, files=files)
+        
+            status_code = r.status_code
+            data = r.json()
+
+            try:
+                if status_code == 201:
+                    replay_ids_in_group.append(data['id'])
+                elif status_code == 409:
+                    payload = {
+                        'group': subgroup_id
+                    }
+                    r = await self._bc_patch_request(ctx, '/replays/{}'.format(data['id']), auth_token=auth_token, json=payload)
+                    if r.status_code == 204:
+                        replay_ids_in_group.append(data['id'])
+                    else:
+                        await ctx.send(":x: {} error: {}".format(r.status_code, r.json()['error']))
+            except:
+                await ctx.send(":x: {} error: {}".format(status_code, data['error']))
+        
+        return replay_ids_in_group
+        
+    async def _rename_replays(self, ctx, uploaded_replays_ids):
+        auth_token = await self._get_auth_token(ctx.guild)
+        renamed = []
+
+        game_number = 1
+        for replay_id in uploaded_replays_ids:
+            endpoint = '/replays/{}'.format(replay_id)
+            payload = {
+                'title': 'Game {}'.format(game_number)
+            }
+            r = await self._bc_patch_request(ctx, endpoint, auth_token=auth_token, json=payload)
+            status_code = r.status_code
+
+            if status_code == 204:
+                renamed.append(replay_id)            
+            else:
+                await ctx.send(":x: {} error.".format(status_code))
+
+            game_number += 1
+        return renamed
+
+    def _delete_temp_files(self, files_to_upload):
+        for replay_filename in files_to_upload:
+            if os.path.exists("temp/{}".format(replay_filename)):
+                os.remove("temp/{}".format(replay_filename))
+        try:
+            os.rmdir("temp") # Remove Temp Folder
+        except OSError:
+            print("Can't remove populated folder.")
+            return False
+        except:
+            print("Uncaught error in delete_temp_files.")
+            return False
+        return True
+
+    async def _get_tier_subgroup_name(self, ctx, tier):
+        tier_num = (await self._get_tier_ranks(ctx))[tier]
+        return '{}{}'.format(tier_num, tier)
+
+    async def _get_all_match_players(self, ctx, match):
+        players = []
+        for team in ['home', 'away']:
+            franchise_role, tier_role = await self.team_manager_cog._roles_for_team(ctx, match[team])
+            team_members = self.team_manager_cog.members_from_team(ctx, franchise_role, tier_role)
+            for player in team_members:
+                players.append(player)
+        return players
+
+    # json db
+    async def _get_auth_token(self, guild):
+        return await self.config.guild(guild).AuthToken()
+    
+    async def _save_auth_token(self, ctx, token):
+        await self.config.guild(ctx.guild).AuthToken.set(token)
+        return True
+
+    async def _get_top_level_group(self, ctx):
+        return await self.config.guild(ctx.guild).TopLevelGroup()
+    
+    async def _save_top_level_group(self, ctx, group_id):
+        await self.config.guild(ctx.guild).TopLevelGroup.set(group_id)
+        return True
+    
+    async def _get_tier_ranks(self, ctx):
+        return await self.config.guild(ctx.guild).TierRank()
+    
+    async def _save_tier_ranks(self, ctx, tier_ranks):
+        await self.config.guild(ctx.guild).TierRanks.set(tier_ranks)
+        return True
+
+    async def _get_account_register(self):
+        return await self.config.AccountRegister()
+    
+    async def _save_account_register(self, account_register):
+        await self.config.AccountRegister.set(account_register)
+
+    

--- a/bcManager/BCManager.py
+++ b/bcManager/BCManager.py
@@ -167,7 +167,7 @@ class BCManager(commands.Cog):
         group_code = await self._get_top_level_group(ctx)
         url = "https://ballchasing.com/group/{}".format(group_code)
         if group_code:
-            await ctx.send("See all season replays in the top level ballchasing group: {}".format())
+            await ctx.send("See all season replays in the top level ballchasing group: {}".format(url))
         else:
             await ctx.send(":x: A ballchasing group has not been set for this season yet.")
 
@@ -175,12 +175,14 @@ class BCManager(commands.Cog):
     @commands.guild_only()
     async def registerAccount(self, ctx, platform, identifier):
         """Allows user to register account for ballchasing requests. This may be found by searching your appearances on ballchasing.com
-        **Note:** Only **steam** accounts can be used to find match replays.
+        
         Examples:
-            [p]registerAccount steam 76561199096013422
-            [p]registerAccount xbox e4b17b0000000900
-            [p]registerAccount ps4 touchetupac2
-            [p]registerAccount epic 76edd61bd58841028a8ee27373ae307a
+        [p]registerAccount steam 76561199096013422
+        [p]registerAccount xbox e4b17b0000000900
+        [p]registerAccount ps4 touchetupac2
+        [p]registerAccount epic 76edd61bd58841028a8ee27373ae307a
+
+        **Note:** Only **steam** accounts can be used to find match replays.
         """
 
         # Check platform
@@ -591,10 +593,11 @@ class BCManager(commands.Cog):
         count = config.search_count
 
         # RFC3339 Date/Time format
-        now = datetime.now(timezone.utc).astimezone().isoformat()
-        adj_char = '+' if '+' in str(now) else '-'
-        zone_adj = "{}{}".format(adj_char, str(now).split(adj_char)[-1])
+        # now = datetime.now(timezone.utc).astimezone().isoformat()
+        # adj_char = '+' if '+' in str(now) else '-'
+        # zone_adj = "{}{}".format(adj_char, str(now).split(adj_char)[-1])
 
+        zone_adj = '-04:00'
         date_string = match['matchDate']
         match_date = datetime.strptime(date_string, '%B %d, %Y').strftime('%Y-%m-%d')
         start_match_date_rfc3339 = "{}T00:00:00{}".format(match_date, zone_adj)
@@ -603,9 +606,9 @@ class BCManager(commands.Cog):
         params = [
             # 'uploader={}'.format(uploader),
             'playlist=private',
-            # 'replay-date-after={}'.format(start_match_date_rfc3339),  # Filters by matches played on this day
-            # 'replay-date-before={}'.format(end_match_date_rfc3339),
-            'count={}'.format(count),
+            'replay-date-after={}'.format(start_match_date_rfc3339),  # Filters by matches played on this day
+            'replay-date-before={}'.format(end_match_date_rfc3339),
+            # 'count={}'.format(count),
             'sort-by={}'.format(sort),
             'sort-dir={}'.format(sort_dir)
         ]
@@ -616,7 +619,7 @@ class BCManager(commands.Cog):
         # Search invoker's replay uploads first
         if member in all_players:
             all_players.remove(member)
-            member.insert(0 member)
+            all_players.insert(0, member)
         
         # Search all players in game for replays until match is found
         for player in all_players:
@@ -739,20 +742,6 @@ class BCManager(commands.Cog):
 
             game_number += 1
         return renamed
-
-    def _delete_temp_files(self, files_to_upload):
-        for replay_filename in files_to_upload:
-            if os.path.exists("temp/{}".format(replay_filename)):
-                os.remove("temp/{}".format(replay_filename))
-        try:
-            os.rmdir("temp") # Remove Temp Folder
-        except OSError:
-            print("Can't remove populated folder.")
-            return False
-        except:
-            print("Uncaught error in delete_temp_files.")
-            return False
-        return True
 
     async def _get_tier_subgroup_name(self, ctx, tier):
         tier_num = (await self._get_tier_ranks(ctx))[tier]

--- a/bcManager/__init__.py
+++ b/bcManager/__init__.py
@@ -1,0 +1,6 @@
+
+from .config import config
+from .bcManager import BCManager
+
+def setup(bot):
+    bot.add_cog(BCManager(bot))

--- a/bcManager/config.py
+++ b/bcManager/config.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+# Discord ID: Steam ID -- maybe handle multiple accounts?
+
+# ###############################################################################
+
+class config:
+    auth_token = 'Ght7UfDSmDeA58GPc3A8QnRfmM93LX7Z6U9g7LG0'
+    top_level_group = 'test-group-cl0dozmu3o'
+    search_count = 10
+    visibility = 'public'
+    team_identification = 'by-player-clusters'                  # setting -- Alternative: 'by-distinct-players'
+    player_identification = 'by-id'                             # setting -- Alternative 'by-name'
+
+    # Ballchasing subgroups: 1Premier, 2Master, etc.
+    tier_rank = {
+        "Premier": 1,
+        "Master": 2,
+        "Elite": 3,
+        "Major": 4,
+        "Minor": 5,
+        "Challenger": 6,
+        "Prospect": 7,
+        "Contender": 8,
+        "Amateur": 9
+    }

--- a/bcManager/config.py
+++ b/bcManager/config.py
@@ -4,8 +4,8 @@ from datetime import datetime
 # ###############################################################################
 
 class config:
-    auth_token = 'Ght7UfDSmDeA58GPc3A8QnRfmM93LX7Z6U9g7LG0'
-    top_level_group = 'test-group-cl0dozmu3o'
+    auth_token = None
+    top_level_group = None
     search_count = 10
     visibility = 'public'
     team_identification = 'by-player-clusters'                  # setting -- Alternative: 'by-distinct-players'

--- a/match/config.py
+++ b/match/config.py
@@ -1,0 +1,110 @@
+
+class config:
+    home_info = ("You are the **home** team. You will create the "
+                "room using the above information. Contact the "
+                "other team when your team is ready to begin the "
+                "match. Do not join a team until the away team starts "
+                "to.\nRemember to ask before the match begins if the other "
+                "team would like to switch server region after 2 "
+                "games.")
+
+    away_info = ("You are the **away** team. You will join the room "
+                "using the above information once the other team "
+                "contacts you. Do not begin joining a team until "
+                "your entire team is ready to begin playing.")
+
+    solo_home_info = ("You are on the **home** team. You are the {0} seed. "
+                "You are responsible for hosting the lobby for all of "
+                "your matches with the following lobby information: ")
+
+    solo_away_info = ("You are on the **away** team. You are the {0} seed. "
+                "You will participate in the following matchups: ")
+                
+
+    solo_home_match_info = ("Your {0} will be against `{1}` at {2}.\n\n")
+
+    solo_away_match_info = ("Your {0} will be against `{1}` at "
+                "{2} with the following lobby info: "
+                "\nName: **{3}**"
+                "\nPassword: **{4}**")
+
+    first_match_descr = ("first **one game** match")
+
+    second_match_descr = ("second **one game** match")
+
+    third_match_descr = ("**three game** series")
+
+    first_match_time = ("10:00 pm ET (7:00 pm PT)")
+
+    second_match_time = ("approximately 10:15 pm ET (7:15 pm PT)")
+
+    third_match_time = ("approximately 10:30 pm ET (7:30 pm PT)")
+
+    solo_matchup = ("{away_player:25s} vs.\t{home_player}")
+
+    stream_info = ("**This match is scheduled to play on stream ** "
+                "(Time slot {time_slot}: {time})"
+                "\nYou are the **{home_or_away}** team. "
+                "A member of the Media Committee will inform you when the lobby is ready. "
+                "Do not join the lobby unless you are playing in the upcoming game. "
+                "Players should not join until instructed to do so via in-game chat. "
+                "\nRemember to inform the Media Committee what server "
+                "region your team would like to play on before games begin."
+                "\n\nLive Stream: <{live_stream}>")
+                
+    regular_info = ("\n\nBe sure that **crossplay is enabled**. Be sure to save replays "
+                    "and screenshots of the end-of-game scoreboard. Do not leave "
+                    "the game until screenshots have been taken. "
+                    "These must be uploaded by one member of your team after the 4-game series "
+                    "is over. Remember that the deadline to reschedule matches is "
+                    "at 10 minutes before the currently scheduled match time. They "
+                    "can be scheduled no later than 11:59 PM ET on the original match day.\n\n")
+
+    playoff_info = ("Playoff matches are a best of 5 series for every round until the finals. "
+                    "Screenshots and replays do not need to be uploaded to the website for "
+                    "playoff matches but you will need to report the scores in #score-reporting.\n\n")
+
+    room_pass = [
+        'octane', 'takumi', 'dominus', 'hotshot', 'batmobile', 'mantis',
+        'paladin', 'twinmill', 'centio', 'breakout', 'animus', 'venom',
+        'xdevil', 'endo', 'masamune', 'merc', 'backfire', 'gizmo',
+        'roadhog', 'armadillo', 'hogsticker', 'luigi', 'mario', 'samus',
+        'sweettooth', 'cyclone', 'imperator', 'jager', 'mantis', 'nimbus',
+        'samurai', 'twinzer', 'werewolf', 'maverick', 'artemis', 'charger',
+        'skyline', 'aftershock', 'boneshaker', 'delorean', 'esper',
+        'fast4wd', 'gazella', 'grog', 'jeep', 'marauder', 'mclaren',
+        'mr11', 'proteus', 'ripper', 'scarab', 'tumbler', 'triton',
+        'vulcan', 'zippy',
+
+        'aquadome', 'beckwith', 'champions', 'dfh', 'mannfield',
+        'neotokyo', 'saltyshores', 'starbase', 'urban', 'utopia',
+        'wasteland', 'farmstead', 'arctagon', 'badlands', 'core707',
+        'dunkhouse', 'throwback', 'underpass', 'badlands',
+
+        '20xx', 'biomass', 'bubbly', 'chameleon', 'dissolver', 'heatwave',
+        'hexed', 'labyrinth', 'parallax', 'slipstream', 'spectre',
+        'stormwatch', 'tora', 'trigon', 'wetpaint',
+
+        'ara51', 'ballacarra', 'chrono', 'clockwork', 'cruxe',
+        'discotheque', 'draco', 'dynamo', 'equalizer', 'gernot', 'hikari',
+        'hypnotik', 'illuminata', 'infinium', 'kalos', 'lobo', 'looper',
+        'photon', 'pulsus', 'raijin', 'reactor', 'roulette', 'turbine',
+        'voltaic', 'wonderment', 'zomba',
+
+        'unranked', 'prospect', 'challenger', 'risingstar', 'allstar',
+        'superstar', 'champion', 'grandchamp', 'bronze', 'silver', 'gold',
+        'platinum', 'diamond',
+
+        'dropshot', 'hoops', 'soccar', 'rumble', 'snowday', 'solo',
+        'doubles', 'standard', 'chaos',
+
+        'armstrong', 'bandit', 'beast', 'boomer', 'buzz', 'cblock',
+        'casper', 'caveman', 'centice', 'chipper', 'cougar', 'dude',
+        'foamer', 'fury', 'gerwin', 'goose', 'heater', 'hollywood',
+        'hound', 'iceman', 'imp', 'jester', 'junker', 'khan', 'marley',
+        'maverick', 'merlin', 'middy', 'mountain', 'myrtle', 'outlaw',
+        'poncho', 'rainmaker', 'raja', 'rex', 'roundhouse', 'sabretooth',
+        'saltie', 'samara', 'scout', 'shepard', 'slider', 'squall',
+        'sticks', 'stinger', 'storm', 'sultan', 'sundown', 'swabbie',
+        'tex', 'tusk', 'viper', 'wolfman', 'yuri'
+    ]

--- a/match/match.py
+++ b/match/match.py
@@ -4,12 +4,13 @@ import random
 from datetime import datetime
 import json
 import discord
+from .config import config
 
 from redbot.core import Config
 from redbot.core import commands
 from redbot.core import checks
 
-defaults = {"MatchDay": 0, "Schedule": {}}
+defaults = {"MatchDay": 0, "Schedule": {}, "Game": "Rocket League"}
 
 class Match(commands.Cog):
     """Used to get the match information"""
@@ -129,6 +130,79 @@ class Match(commands.Cog):
                                                          team_name)
                 )
         await ctx.message.delete()
+
+    @commands.command(aliases=['lobbyup', 'up'])
+    @commands.guild_only()
+    async def lobbyready(self, ctx):
+        """Informs players of the opposing team that the private match lobby is ready and joinable."""
+        match_day = await self._match_day(ctx)
+        teams = await self.team_manager.teams_for_user(ctx, user)
+        
+        if not (match_day and teams):
+            return
+
+        team_name = teams[0]
+        match_data = await self.get_match_from_day_team(ctx, match_day, team_name)
+        opposing_team = match_data['home'] if team_name == match_data['away'] else match_data['away']
+        
+        opp_franchise_role, tier_role = await self._roles_for_team(ctx, opposing_team)
+        opp_captain = await self.team_manager(ctx, opp_franchise_role, tier_role)
+        opposing_roster = self.team_manager.members_from_team(ctx, opp_franchise_role, tier_role)
+        opposing_roster.remove(opp_captain)
+        
+        message = "Please join your match against the **{}** with the following lobby information:".format(opposing_team)
+        message += "\n\n**Name:** {}".format(match_data['roomName'])
+        message += "\n**Password:** {}".format(match_data['roomPass'])
+        
+        embed = discord.Embed(title="Your Opponents are ready!", color=tier_role.color, description=message)
+
+        # only send to captain if in-game
+        if await self._is_in_game(opp_captain):
+            return await opp_captain.send(embed)
+        
+        # send to captain if status is online
+        if opp_captain.status == "online":
+            await opp_captain.send(embed)
+
+        # send to all rostered players in-game if captain isn't in-game
+        actively_playing = []
+        for player in opposing_roster:
+            if await self._is_in_game(player):
+                actively_playing.append(player)
+        
+        if actively_playing:
+            for player in actively_playing:
+                await player.send(embed)
+            return
+        
+        # send to all online players if no players are in-game
+        online = []
+        for player in opposing_roster:
+            if player.status == "online":
+                online.append(player)
+        
+        if online:
+            for player in online:
+                await player.send(embed)
+            return
+
+        # send to everyone if nobody is online, including opposing team's GM
+        opposing_roster.append(opp_captain)
+        for player in opposing_roster:
+            await player.send(embed)
+        
+        # Don't double send to GM
+        opposing_gm = self.team_manager._get_gm(ctx, opp_franchise_role)
+        if opposing_gm in opposing_roster:
+            return
+
+        embed.description += "\n_This message has been sent to you because none of the players on your "
+        embed.description += "{} team, the {} appear to be in-game or online._".format(tier_role.name, opposing_team)
+
+        await opposing_gm.send(embed)
+        await ctx.message.add_reaction("\U00002705") # white check mark
+        # TODO: Maybe react with franchise emojis? could be fun :)
+
 
     @commands.command()
     @commands.guild_only()
@@ -359,8 +433,6 @@ class Match(commands.Cog):
             
         return await self._create_normal_match_embed(ctx, embed, match, user_team_name, home, away)
 
-        
-
     async def _format_match_message(self, ctx, match_index, user_team_name):
         matches = await self._matches(ctx)
         match = matches[match_index]
@@ -410,13 +482,13 @@ class Match(commands.Cog):
                     return match
         return None
 
-    async def set_match_on_stream(self, ctx, match_day, team_name, stream_info):
+    async def set_match_on_stream(self, ctx, match_day, team_name, stream_data):
         matches = await self._matches(ctx)
         for match in matches:
             if not match['matchDay'] == match_day:
                 break 
             if match['home'] == team_name or match['away'] == team_name:
-                match['streamDetails'] = stream_info
+                match['streamDetails'] = stream_data
                 await self._save_matches(ctx, matches)
                 return True
         return False
@@ -437,14 +509,14 @@ class Match(commands.Cog):
         if user_team_name:
             if stream_details:
                 if user_team_name.casefold() == home.casefold():
-                    additional_info += stream_info.format(
+                    additional_info += config.stream_info.format(
                         home_or_away='home', 
                         time_slot=stream_details['slot'],
                         time=stream_details['time'],
                         live_stream=stream_details['live_stream']
                     )
                 elif user_team_name.casefold() == away.casefold():
-                    additional_info += stream_info.format(
+                    additional_info += config.stream_info.format(
                         home_or_away='away', 
                         time_slot=stream_details['slot'],
                         time=stream_details['time'],
@@ -452,17 +524,17 @@ class Match(commands.Cog):
                     )
             else:
                 if user_team_name == home:
-                    additional_info += home_info
+                    additional_info += config.home_info
                 elif user_team_name == away:
-                    additional_info += away_info
+                    additional_info += config.away_info
                 
 
         # TODO: Add other info (complaint form, disallowed maps,
         #       enable crossplay, etc.)
         # REGULAR SEASON INFO
-        additional_info += regular_info
+        additional_info += config.regular_info
         # PLAYOFF INFO
-        #additional_info += playoff_info
+        #additional_info += config.playoff_info
         return additional_info
 
     async def _create_normal_match_embed(self, ctx, embed, match, user_team_name, home, away):
@@ -521,19 +593,19 @@ class Match(commands.Cog):
         message = ""
         if user_team_name.casefold() == home.casefold():
             ordered_opponent_names, ordered_opponent_seeds = await player_ratings_cog.get_ordered_opponent_names_and_seeds(ctx, seed, True, away)
-            message += solo_home_info.format(seed)
+            message += config.solo_home_info.format(seed)
             message += "\n\n**Lobby Info:**\nName: **{0}**\nPassword: **{1}**\n\n".format(match['roomName'] + str(seed), match['roomPass'] + str(seed))
-            message += solo_home_match_info.format(first_match_descr, ordered_opponent_names[0], first_match_time)
-            message += solo_home_match_info.format(second_match_descr, ordered_opponent_names[1], second_match_time)
-            message += solo_home_match_info.format(third_match_descr, ordered_opponent_names[2], third_match_time)
+            message += config.solo_home_match_info.format(config.first_match_descr, ordered_opponent_names[0], config.first_match_time)
+            message += config.solo_home_match_info.format(config.second_match_descr, ordered_opponent_names[1], config.second_match_time)
+            message += config.solo_home_match_info.format(config.third_match_descr, ordered_opponent_names[2], config.third_match_time)
         else:
             ordered_opponent_names, ordered_opponent_seeds = await player_ratings_cog.get_ordered_opponent_names_and_seeds(ctx, seed, False, home)
-            message += solo_away_info.format(seed)
-            message += "\n\n{0}".format(solo_away_match_info.format(first_match_descr, ordered_opponent_names[0], first_match_time, 
+            message += config.solo_away_info.format(seed)
+            message += "\n\n{0}".format(config.solo_away_match_info.format(config.first_match_descr, ordered_opponent_names[0], config.first_match_time, 
                 match['roomName'] + str(ordered_opponent_seeds[0]), match['roomPass'] + str(ordered_opponent_seeds[0])))
-            message += "\n\n{0}".format(solo_away_match_info.format(second_match_descr, ordered_opponent_names[1], second_match_time, 
+            message += "\n\n{0}".format(config.solo_away_match_info.format(config.second_match_descr, ordered_opponent_names[1], config.second_match_time, 
                 match['roomName'] + str(ordered_opponent_seeds[1]), match['roomPass'] + str(ordered_opponent_seeds[1])))
-            message += "\n\n{0}".format(solo_away_match_info.format(third_match_descr, ordered_opponent_names[2], third_match_time, 
+            message += "\n\n{0}".format(config.solo_away_match_info.format(config.third_match_descr, ordered_opponent_names[2], config.third_match_time, 
                 match['roomName'] + str(ordered_opponent_seeds[2]), match['roomPass'] + str(ordered_opponent_seeds[2])))
         return message
 
@@ -541,21 +613,21 @@ class Match(commands.Cog):
         message = ""
         try:
             # First match
-            message += "\n\nThe first **one game** series will begin at {0} and will include the following matchups: ".format(first_match_time)
+            message += "\n\nThe first **one game** series will begin at {0} and will include the following matchups: ".format(config.first_match_time)
             message += "```"
             message += await self._create_matchup_string(ctx, player_ratings_cog, home, away, 1, 3)
             message += "\n" + await self._create_matchup_string(ctx, player_ratings_cog, home, away, 2, 1)
             message += "\n" + await self._create_matchup_string(ctx, player_ratings_cog, home, away, 3, 2)
             message += "```"
             # Second match
-            message += "\n\nThe second **one game** series will begin at {0} and will include the following matchups: ".format(second_match_time)
+            message += "\n\nThe second **one game** series will begin at {0} and will include the following matchups: ".format(config.second_match_time)
             message += "```"
             message += await self._create_matchup_string(ctx, player_ratings_cog, home, away, 1, 2)
             message += "\n" + await self._create_matchup_string(ctx, player_ratings_cog, home, away, 2, 3)
             message += "\n" + await self._create_matchup_string(ctx, player_ratings_cog, home, away, 3, 1)
             message += "```"
             # Third match
-            message += "\n\nThe final **three game** series will begin at {0} and will include the following matchups: ".format(third_match_time)
+            message += "\n\nThe final **three game** series will begin at {0} and will include the following matchups: ".format(config.third_match_time)
             message += "```"
             message += await self._create_matchup_string(ctx, player_ratings_cog, home, away, 1, 1)
             message += "\n" + await self._create_matchup_string(ctx, player_ratings_cog, home, away, 2, 2)
@@ -568,117 +640,31 @@ class Match(commands.Cog):
     async def _create_matchup_string(self, ctx, player_ratings_cog, home, away, home_seed, away_seed):
         away_player_nick = str((await player_ratings_cog.get_member_by_team_and_seed(ctx, away, away_seed)).nick) # We convert to string to handle None cases
         home_player_nick = str((await player_ratings_cog.get_member_by_team_and_seed(ctx, home, home_seed)).nick) # We convert to string to handle None cases
-        return solo_matchup.format(away_player = away_player_nick, home_player = home_player_nick)
+        return config.solo_matchup.format(away_player = away_player_nick, home_player = home_player_nick)
 
     def _generate_name_pass(self):
-        return room_pass[random.randrange(len(room_pass))]
+        return config.room_pass[random.randrange(len(room_pass))]
 
-# TODO: Load from file?
-room_pass = [
-    'octane', 'takumi', 'dominus', 'hotshot', 'batmobile', 'mantis',
-    'paladin', 'twinmill', 'centio', 'breakout', 'animus', 'venom',
-    'xdevil', 'endo', 'masamune', 'merc', 'backfire', 'gizmo',
-    'roadhog', 'armadillo', 'hogsticker', 'luigi', 'mario', 'samus',
-    'sweettooth', 'cyclone', 'imperator', 'jager', 'mantis', 'nimbus',
-    'samurai', 'twinzer', 'werewolf', 'maverick', 'artemis', 'charger',
-    'skyline', 'aftershock', 'boneshaker', 'delorean', 'esper',
-    'fast4wd', 'gazella', 'grog', 'jeep', 'marauder', 'mclaren',
-    'mr11', 'proteus', 'ripper', 'scarab', 'tumbler', 'triton',
-    'vulcan', 'zippy',
+    async def _is_in_game(self, member):
+        if not member.activities:
+            return False 
+        
+        playing = False
+        game = await self._get_guild_game(member.guild)
 
-    'aquadome', 'beckwith', 'champions', 'dfh', 'mannfield',
-    'neotokyo', 'saltyshores', 'starbase', 'urban', 'utopia',
-    'wasteland', 'farmstead', 'arctagon', 'badlands', 'core707',
-    'dunkhouse', 'throwback', 'underpass', 'badlands',
+        for activity in member.activities:
+            if type(activity) == discord.Game:
+                if activity.name == game:
+                    playing = True
+                    try:
+                        playing = not activity.end or activity.end > datetime.utcnow()
+                    except:
+                        playing = not activity.end
+                    return playing
 
-    '20xx', 'biomass', 'bubbly', 'chameleon', 'dissolver', 'heatwave',
-    'hexed', 'labyrinth', 'parallax', 'slipstream', 'spectre',
-    'stormwatch', 'tora', 'trigon', 'wetpaint',
+    async def _save_guild_game(self, guild, game):
+        await self.config.guild(guild).Game.set(game)
 
-    'ara51', 'ballacarra', 'chrono', 'clockwork', 'cruxe',
-    'discotheque', 'draco', 'dynamo', 'equalizer', 'gernot', 'hikari',
-    'hypnotik', 'illuminata', 'infinium', 'kalos', 'lobo', 'looper',
-    'photon', 'pulsus', 'raijin', 'reactor', 'roulette', 'turbine',
-    'voltaic', 'wonderment', 'zomba',
-
-    'unranked', 'prospect', 'challenger', 'risingstar', 'allstar',
-    'superstar', 'champion', 'grandchamp', 'bronze', 'silver', 'gold',
-    'platinum', 'diamond',
-
-    'dropshot', 'hoops', 'soccar', 'rumble', 'snowday', 'solo',
-    'doubles', 'standard', 'chaos',
-
-    'armstrong', 'bandit', 'beast', 'boomer', 'buzz', 'cblock',
-    'casper', 'caveman', 'centice', 'chipper', 'cougar', 'dude',
-    'foamer', 'fury', 'gerwin', 'goose', 'heater', 'hollywood',
-    'hound', 'iceman', 'imp', 'jester', 'junker', 'khan', 'marley',
-    'maverick', 'merlin', 'middy', 'mountain', 'myrtle', 'outlaw',
-    'poncho', 'rainmaker', 'raja', 'rex', 'roundhouse', 'sabretooth',
-    'saltie', 'samara', 'scout', 'shepard', 'slider', 'squall',
-    'sticks', 'stinger', 'storm', 'sultan', 'sundown', 'swabbie',
-    'tex', 'tusk', 'viper', 'wolfman', 'yuri'
-]
-
-home_info = ("You are the **home** team. You will create the "
-            "room using the above information. Contact the "
-            "other team when your team is ready to begin the "
-            "match. Do not join a team until the away team starts "
-            "to.\nRemember to ask before the match begins if the other "
-            "team would like to switch server region after 2 "
-            "games.")
-
-away_info = ("You are the **away** team. You will join the room "
-            "using the above information once the other team "
-            "contacts you. Do not begin joining a team until "
-            "your entire team is ready to begin playing.")
-
-solo_home_info = ("You are on the **home** team. You are the {0} seed. "
-            "You are responsible for hosting the lobby for all of "
-            "your matches with the following lobby information: ")
-
-solo_away_info = ("You are on the **away** team. You are the {0} seed. "
-            "You will participate in the following matchups: ")
-            
-
-solo_home_match_info = ("Your {0} will be against `{1}` at {2}.\n\n")
-
-solo_away_match_info = ("Your {0} will be against `{1}` at "
-            "{2} with the following lobby info: "
-            "\nName: **{3}**"
-            "\nPassword: **{4}**")
-
-first_match_descr = ("first **one game** match")
-
-second_match_descr = ("second **one game** match")
-
-third_match_descr = ("**three game** series")
-
-first_match_time = ("10:00 pm ET (7:00 pm PT)")
-
-second_match_time = ("approximately 10:15 pm ET (7:15 pm PT)")
-
-third_match_time = ("approximately 10:30 pm ET (7:30 pm PT)")
-
-solo_matchup = ("{away_player:25s} vs.\t{home_player}")
-
-stream_info = ("**This match is scheduled to play on stream ** "
-            "(Time slot {time_slot}: {time})"
-            "\nYou are the **{home_or_away}** team. "
-            "A member of the Media Committee will inform you when the lobby is ready. "
-            "Do not join the lobby unless you are playing in the upcoming game. "
-            "Players should not join until instructed to do so via in-game chat. "
-            "\nRemember to inform the Media Committee what server "
-            "region your team would like to play on before games begin."
-            "\n\nLive Stream: <{live_stream}>")
-            
-regular_info = ("\n\nBe sure that **crossplay is enabled**. Be sure to save replays "
-                "and screenshots of the end-of-game scoreboard. Do not leave "
-                "the game until screenshots have been taken. "
-                "These must be uploaded by one member of your team after the 4-game series "
-                "is over. Remember that the deadline to reschedule matches is "
-                "at 10 minutes before the currently scheduled match time. They "
-                "can be scheduled no later than 11:59 PM ET on the original match day.\n\n")
-
-playoff_info = ("Playoff matches are a best of 5 series for every round until the finals. "
-                "Screenshots and replays do not need to be uploaded to the website for "
-                "playoff matches but you will need to report the scores in #score-reporting.\n\n")
+    async def _get_guild_game(self, guild):
+        return await self.config.guild(guild).Game()
+    

--- a/match/match.py
+++ b/match/match.py
@@ -146,7 +146,7 @@ class Match(commands.Cog):
 
         if not match_data:
             return await ctx.send(":x: Match could not be found")
-            
+
         opposing_team = match_data['home'] if team_name == match_data['away'] else match_data['away']
         
         opp_franchise_role, tier_role = await self._roles_for_team(ctx, opposing_team)
@@ -160,6 +160,7 @@ class Match(commands.Cog):
         
         embed = discord.Embed(title="Your Opponents are ready!", color=tier_role.color, description=message)
 
+        # TODO: cover scenario where captain has promoted
         # only send to captain if in-game
         if await self._is_in_game(opp_captain):
             return await opp_captain.send(embed)

--- a/match/match.py
+++ b/match/match.py
@@ -143,6 +143,10 @@ class Match(commands.Cog):
 
         team_name = teams[0]
         match_data = await self.get_match_from_day_team(ctx, match_day, team_name)
+
+        if not match_data:
+            return await ctx.send(":x: Match could not be found")
+            
         opposing_team = match_data['home'] if team_name == match_data['away'] else match_data['away']
         
         opp_franchise_role, tier_role = await self._roles_for_team(ctx, opposing_team)
@@ -202,7 +206,6 @@ class Match(commands.Cog):
         await opposing_gm.send(embed)
         await ctx.message.add_reaction("\U00002705") # white check mark
         # TODO: Maybe react with franchise emojis? could be fun :)
-
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
- Account register stores accounts on various platforms for all players (for now, the only relevant platform is steam)
- Admins commands configure the auth key, top-level-group, tier rank structure, etc
- Players can manage their own accounts
- Players can run `<p>bcreport` to report replays from the current, or otherwise specified match day
- Adds `<p>lobbyready` command, which informs member of the opposing/away team that the match lobby is up and joinable