### PR TITLE
Matches Update +some

### DIFF
--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -59,8 +59,10 @@ class SixMansQueue:
         return self.queue.qsize() >= self.queueMaxSize
 
     async def send_message(self, message='', embed=None):
+        messages = []
         for channel in self.channels:
-            await channel.send(message, embed=embed)
+            messages.append(await channel.send(message, embed=embed))
+        return messages
 
     async def set_team_selection(self, team_selection):
         self.teamSelection = team_selection

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -1,3 +1,4 @@
+from sys import prefix
 import discord
 import re
 import ast
@@ -173,8 +174,22 @@ class TeamManager(commands.Cog):
         """Provides a list of all the franchises set up in the server 
         including the name of the GM for each franchise"""
         franchise_roles = self._get_all_franchise_roles(ctx)
-        embed = discord.Embed(title="Franchises:", color=discord.Colour.blue(), 
-            description="{}".format("\n".join([role.name for role in franchise_roles])), thumbnail=ctx.guild.icon_url)
+        franchise_roles.sort(key=lambda role: role.name.lower())
+        
+        prefixes = []
+        franchises = []
+        gms = []
+
+        for role in franchise_roles:
+            franchise_role, gm_name, franchise_prefix, franchise_name = await self._get_franchise_data(ctx, role)
+            prefixes.append(franchise_prefix)
+            franchises.append(franchise_name)
+            gms.append(gm_name)
+
+        embed = discord.Embed(title="Franchises", color=discord.Colour.blue(), thumbnail=ctx.guild.icon_url)
+        embed.add_field(name="Pfx.", value="{}\n".format("\n".join(prefixes)), inline=True)
+        embed.add_field(name="Franchise", value="{}\n".format("\n".join(franchises)), inline=True)
+        embed.add_field(name="General Manager", value="{}\n".format("\n".join(gms)), inline=True)
         await ctx.send(embed=embed)
 
     @commands.command()
@@ -277,9 +292,11 @@ class TeamManager(commands.Cog):
     async def listTiers(self, ctx):
         """Provides a list of all the tiers set up in the server"""
         tiers = await self.tiers(ctx)
+        tier_roles = [self._get_tier_role(ctx, tier) for tier in tiers]
+        tier_roles.sort(key=lambda role: role.position, reverse=True)
         if tiers:
             await ctx.send(
-                "Tiers set up in this server: {0}".format(", ".join(tiers)))
+                "Tiers set up in this server: {0}".format(", ".join(role.mention for role in tier_roles)))
         else:
             await ctx.send("No tiers set up in this server.")
 
@@ -502,10 +519,20 @@ class TeamManager(commands.Cog):
             return False
 
     async def _get_franchise_data(self, ctx, franchise_identifier):
+        """Returns franchise data as 4-set-tuple from a franchise identifier (Franchise name, prefix, role, GM name)."""
         franchise_found = False
+
+        # Role Identifier
+        if franchise_identifier in self._get_all_franchise_roles(ctx):
+            franchise_found = True
+            franchise_role = franchise_identifier
+            gm_name = self._get_gm_name(franchise_role)
+            franchise_prefix = await self.prefix_cog._get_gm_prefix(ctx, gm_name)
+            franchise_name = self.get_franchise_name_from_role(franchise_role)
+
         # GM/Prefix Identifier
         prefixes = await self.prefix_cog._prefixes(ctx)
-        if(len(prefixes.items()) > 0):
+        if not franchise_found and prefixes:
             for key, value in prefixes.items():
                 if franchise_identifier.lower() == key.lower() or franchise_identifier.lower() == value.lower():
                     franchise_found = True

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -923,14 +923,6 @@ class TeamManager(commands.Cog):
         if teams and team_name in teams:
             team_roles = await self._team_roles(ctx)
             team_data = team_roles.setdefault(team_name, {})
-            # if not team_data:
-            #     team_data = team_roles.setdefault(team_name.title(), {})
-            # if not team_data:
-            #     team_data = team_roles.setdefault(team_name.capitalize(), {})
-            # if not team_data:
-            #     team_data = team_roles.setdefault(team_name.upper(), {})
-            # if not team_data:
-            #     team_data = team_roles.setdefault(team_name.lower(), {})
             franchise_role_id = team_data["Franchise Role"]
             tier_role_id = team_data["Tier Role"]
             franchise_role = self._find_role(ctx, franchise_role_id)

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -194,7 +194,7 @@ class TeamManager(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    async def teams(self, ctx, *, franchise_tier_prefix: str):
+    async def teams(self, ctx, *, franchise_tier_identifier: str):
         """Returns a list of teams based on the input. 
         You can either give it the name of a franchise, a tier, or the prefix for a franchise.
         
@@ -202,29 +202,22 @@ class TeamManager(commands.Cog):
         \t[p]teams The Ocean
         \t[p]teams Challenger
         \t[p]teams OCE"""
-        # Prefix
-        prefixes = await self.prefix_cog._prefixes(ctx)
-        if(len(prefixes.items()) > 0):
-            for key, value in prefixes.items():
-                if franchise_tier_prefix.lower() == value.lower():
-                    gm_name = key
-                    franchise_role = self._get_franchise_role(ctx, gm_name)
-                    await ctx.send(embed=await self._format_teams_for_franchise(ctx, franchise_role))
-                    return
+
+        # Franchise Identifier
+        franchise_data = await self._get_franchise_data(ctx, franchise_tier_identifier)
+        if franchise_data:
+            franchise_role, gm_name, franchise_prefix, franchise_name = franchise_data
+            await ctx.send(embed=await self._format_teams_for_franchise(ctx, franchise_role))
+            return
 
         # Tier
         tiers = await self.tiers(ctx)
         for tier in tiers:
-            if tier.lower() == franchise_tier_prefix.lower():
+            if tier.lower() == franchise_tier_identifier.lower():
                 await ctx.send(embed=await self._format_teams_for_tier(ctx, tier))
                 return
 
-        # Franchise name
-        franchise_role = self.get_franchise_role_from_name(ctx, franchise_tier_prefix)
-        if franchise_role is not None:
-            await ctx.send(embed=await self._format_teams_for_franchise(ctx, franchise_role))
-        else:
-            await ctx.send("No franchise, tier, or prefix with name: {0}".format(franchise_tier_prefix))
+        await ctx.send("No tier, franchise, prefix, or GM with name: {0}".format(franchise_tier_identifier))
 
     @commands.command()
     @commands.guild_only()
@@ -930,6 +923,14 @@ class TeamManager(commands.Cog):
         if teams and team_name in teams:
             team_roles = await self._team_roles(ctx)
             team_data = team_roles.setdefault(team_name, {})
+            # if not team_data:
+            #     team_data = team_roles.setdefault(team_name.title(), {})
+            # if not team_data:
+            #     team_data = team_roles.setdefault(team_name.capitalize(), {})
+            # if not team_data:
+            #     team_data = team_roles.setdefault(team_name.upper(), {})
+            # if not team_data:
+            #     team_data = team_roles.setdefault(team_name.lower(), {})
             franchise_role_id = team_data["Franchise Role"]
             tier_role_id = team_data["Tier Role"]
             franchise_role = self._find_role(ctx, franchise_role_id)


### PR DESCRIPTION
# Matches
- Refactors how matches are stored. Removes `TeamDays` and separates matches by tier. This enables teams to have multiple matches on one match day. The dictionary/json follows the following template:
```json
{
  "<Match Day>": "X",
  "Schedules": {
    "<Tier Name>": {
      "<Match Day>": [
          {
              "matchDay": "<Match Day>",
              "matchDate": "May 10, 2021",
              "home": "<Home Team>",
              "away": "<Away Team>",
              "roomName": "<Lobby Name>",
              "roomPass": "<Lobby Password>",
              "streamDetails": null
            }
        ]
    }
  }
}
```
- Replaces accessor methods with one simple command, `get_team_matches(self, ctx, team_name, match_day=None)`, which returns a list of matches for a specific team. There are currently no references without `match_day` specified, but in the event that it is `None`, it will return all registered matches for the season.
- Updates format functions to pass the `match` instead of the `match_index`
- The `match` command will forward all matches found from `get_team_matches` with a specified match day

# Team Manager
- `tiers` command will sort (by role position) and mention tier role (no ping) in response
- `teams` command changes `franchise_tier_prefix` variable to `franchise_tier_identifier`
- `teams` command accepts GM name as franchise identifier
- `franchises` command sorts by team name, and uses embed fields to represent each franchise's prefix, name, and GM.