### PR TITLE
Six Mans will never be the same v2

### DIFF
--- a/sixMans/README.md
+++ b/sixMans/README.md
@@ -31,6 +31,14 @@ The `<p>setCategory` can be used to set the category that contains the 6 mans te
 <p>setCategory <cateory id>
 ```
 
+### Set Queue Timeout
+
+The `<p>setQueueTimeout` can be used to declare how long in minutes a player may wait in a queue before being timed out (Default: 240)
+
+```
+<p>setQueueTimeout <minutes>
+```
+
 ### Set Helper Role
 
 Sets the role that will be assigned to individuals to resolve issues with 6 mans queues and games.
@@ -43,6 +51,8 @@ Sets the role that will be assigned to individuals to resolve issues with 6 mans
 
 # Regular Use
 
+#### Common Commands:
+
 #### `<p>q` - Queue for a 6 mans series
 
 #### `<p>dq` - De-Queue from a 6 mans series
@@ -51,6 +61,16 @@ Sets the role that will be assigned to individuals to resolve issues with 6 mans
 
 #### `<p>cg` - Cancel Game
 
+#### Information:
+
+#### `<p>status` - Shows all players who are in the queue
+
+#### `<p>qi` - Shows all "Queue Info"
+
+#### `<p>qlb <timeframe> [queue_name]` - Gets a leaderboard for a timeframe ~~and queue if specified~~
+
+#### `<p>rank [timeframe]` - Enables a player to get a player card of their 6mans rating and overall win statistics
+
 <br>
 
 # Helper Commands
@@ -58,6 +78,8 @@ Sets the role that will be assigned to individuals to resolve issues with 6 mans
 #### `<p>cag` - "Check Active Games" - Lists all ongoing 6 mans series
 
 #### `<p>getQueueNames` - Lists names of available queues
+
+#### `<p>fts <team selection> [Queue ID]` - Force team selection
 
 #### `<p>fr <winner>` - Forces result of 6 mans series (Blue/Orange)
 

--- a/sixMans/README.md
+++ b/sixMans/README.md
@@ -79,7 +79,7 @@ Sets the role that will be assigned to individuals to resolve issues with 6 mans
 
 #### `<p>getQueueNames` - Lists names of available queues
 
-#### `<p>fts <team selection> [Queue ID]` - Force team selection
+#### `<p>fts <team selection> [Queue ID]` - Force team selection for a popped queue game
 
 #### `<p>fr <winner>` - Forces result of 6 mans series (Blue/Orange)
 

--- a/sixMans/README.md
+++ b/sixMans/README.md
@@ -33,10 +33,18 @@ The `<p>setCategory` can be used to set the category that contains the 6 mans te
 
 ### Set Queue Timeout
 
-The `<p>setQueueTimeout` can be used to declare how long in minutes a player may wait in a queue before being timed out (Default: 240)
+The `<p>setQueueTimeout` can be used to declare how long in minutes a player may wait in a queue before being timed out (Default: 240). This value will apply to all queues set up in the guild.
 
 ```
 <p>setQueueTimeout <minutes>
+```
+
+### Set Queue Sizes
+
+The `<p>setQueueMaxSize` can be used to declare how many players must be in a queue for it to pop (Default: 6). This value will apply to all queues set up in the guild.
+
+```
+<p>setQueueMaxSize <max_size>
 ```
 
 ### Set Helper Role

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -12,9 +12,10 @@ from .queue import SixMansQueue
 
 
 SELECTION_MODES  = {
-    0x1F3B2: Strings.RANDOM_TS,     # game_die
-    0x1F1E8: Strings.CAPTAINS_TS,   # C
-    0x0262F: Strings.BALANCED_TS,   # Ying&Yang
+    0x1F3B2: Strings.RANDOM_TS,         # game_die
+    0x1F1E8: Strings.CAPTAINS_TS,       # C
+    0x0262F: Strings.BALANCED_TS,       # yin_yang
+    0x1F530: Strings.SELF_PICKING_TS    # beginner
 }
 
 class Game:

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -558,16 +558,21 @@ class Game:
         embed.set_thumbnail(url=self.queue.guild.icon_url)
 
         # List teams as they stand
-        blue_players = ', '.join(p.mention for p in self.blue) if self.blue else '<No Players>'
-        orange_players = ', '.join(p.mention for p in self.orange) if self.orange else '<No Players>'
-        unplaced_players = ', '.join(p.mention for p in self.players) if self.players else '<No Players>'
+        no_players_str = '[No Players]'
+        blue_players = ', '.join(p.mention for p in self.blue) if self.blue else no_players_str
+        orange_players = ', '.join(p.mention for p in self.orange) if self.orange else no_players_str
+        unplaced_players = ', '.join(p.mention for p in self.players) if self.players else no_players_str
         
+        ts_emoji = self._get_ts_emoji()
+        embed.add_field(name="Team Selection", value="{} {}".format(ts_emoji, self.teamSelection), inline=False)
         embed.add_field(name="Blue Team", value=blue_players, inline=False)
         embed.add_field(name="Orange Team", value=orange_players, inline=False)
         embed.add_field(name="Unplaced Players", value=unplaced_players, inline=False)
 
+        help_message = "If you think the bot isn't working correctly or have suggestions to improve it, please contact adammast."
         if self.helper_role:
-            embed.add_field(name="Help", value="If you need any help or have questions please contact someone with the {} role.".format(self.helper_role.mention))
+            help_message = "If you need any help or have questions please contact someone with the {0} role. ".format(self.helper_role.mention) + help_message
+        embed.add_field(name="Help", value=help_message, inline=False)
         
         embed.set_footer(text="Game ID: {}".format(self.id))
         return embed

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -204,7 +204,7 @@ class Game:
     async def process_team_selection_method(self, team_selection=None):
         if not team_selection:
             team_selection = self.teamSelection
-        self.reset_players()
+        self.full_player_reset()
         team_selection = team_selection.lower()
         helper_role = self.helper_role
         if team_selection == Strings.VOTE_TS.lower():
@@ -235,6 +235,15 @@ class Game:
         captain_picking = self.captains[0] if pick == 'blue' else self.captains[1]
         
         if user != captain_picking:
+            self.info_message = await self.textChannel.fetch_message(self.info_message.id)
+            for this_react in self.info_message.reactions:
+                this_react:discord.Reaction
+                reacted_members = await this_react.users().flatten()
+                if user in reacted_members:
+                    try:
+                        await this_react.remove(user)
+                    except:
+                        pass
             return False
         
         # get player from reaction
@@ -282,6 +291,7 @@ class Game:
         votes = {}
         self.info_message = await self.textChannel.fetch_message(self.info_message.id) # this is needed to get the up to date reactions for a message
         for this_react in self.info_message.reactions:
+            this_react:discord.Reaction
             react_hex_i = self._hex_i_from_emoji(this_react.emoji)
             if react_hex_i in SELECTION_MODES:
                 reacted_members = await this_react.users().flatten()
@@ -442,7 +452,7 @@ class Game:
 
         else:
             team_color = discord.Colour.green()
-            description="Teams have been set!"
+            description="Teams are finalized!"
 
         embed = discord.Embed(
             title="{} Game | Team Selection".format(self.textChannel.name.replace('-', ' ').title()[4:]),
@@ -573,6 +583,11 @@ class Game:
         for key, value in SELECTION_MODES.items():
             if value == self.teamSelection:
                 return self._get_pick_reaction(key)
+
+    def full_player_reset(self):
+        self.reset_players()
+        self.blue = set()
+        self.orange = set()
 
     def reset_players(self):
         self.players.update(self.orange)

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -132,42 +132,6 @@ class Game:
         reacts = [hex(key) for key in SELECTION_MODES.keys()]
         await self._add_reactions(reacts, self.info_message)
 
-    async def pick_balanced_teams(self):
-        balanced_teams, balance_score = self.get_balanced_teams()
-        self.balance_score = balance_score
-        # Pick random balanced team
-        blue = random.choice(balanced_teams)
-        orange = []
-        for player in self.players:
-            if player not in blue:
-                orange.append(player)
-        for player in blue:
-            await self.add_to_blue(player)
-        for player in orange:
-            await self.add_to_orange(player)
-        
-        self.reset_players()
-        self.get_new_captains_from_teams()
-
-        await self.update_game_info()
-        
-    async def pick_random_teams(self):
-        self.blue = set()
-        self.orange = set()
-        for player in random.sample(self.players, int(len(self.players)//2)):
-            await self.add_to_orange(player)
-        blue = [player for player in self.players]
-        for player in blue:
-            await self.add_to_blue(player)
-        self.reset_players()
-        self.get_new_captains_from_teams()
-
-        await self.update_game_info()
-
-    async def shuffle_players(self):
-        await self.pick_random_teams()
-        await self.info_message.add_reaction(Strings.SHUFFLE_REACT)
-
     async def captains_pick_teams(self, helper_role=None):
         if not helper_role:
             helper_role = self.helper_role
@@ -197,6 +161,45 @@ class Game:
         
         await self._add_reactions(self.react_player_picks.keys(), self.info_message)
 
+    async def pick_random_teams(self):
+        self.blue = set()
+        self.orange = set()
+        for player in random.sample(self.players, int(len(self.players)//2)):
+            await self.add_to_orange(player)
+        blue = [player for player in self.players]
+        for player in blue:
+            await self.add_to_blue(player)
+        self.reset_players()
+        self.get_new_captains_from_teams()
+
+        await self.update_game_info()
+
+    async def pick_balanced_teams(self):
+        balanced_teams, balance_score = self.get_balanced_teams()
+        self.balance_score = balance_score
+        # Pick random balanced team
+        blue = random.choice(balanced_teams)
+        orange = []
+        for player in self.players:
+            if player not in blue:
+                orange.append(player)
+        for player in blue:
+            await self.add_to_blue(player)
+        for player in orange:
+            await self.add_to_orange(player)
+        
+        self.reset_players()
+        self.get_new_captains_from_teams()
+
+        await self.update_game_info()
+    
+    async def self_picking_teams(self):
+        pass
+
+    async def shuffle_players(self):
+        await self.pick_random_teams()
+        await self.info_message.add_reaction(Strings.SHUFFLE_REACT)
+
 # Team Selection helpers
     async def process_team_selection_method(self, team_selection=None):
         if not team_selection:
@@ -213,6 +216,8 @@ class Game:
             await self.shuffle_players()
         elif team_selection == Strings.BALANCED_TS.lower():
             await self.pick_balanced_teams()
+        elif team_selection == Strings.SELF_PICKING_TS.lower():
+            await self.self_picking_teams()
         elif team_selection == Strings.DEFAULT_TS.lower():
             if self.queue.teamSelection.lower() != team_selection:
                 return self.process_team_selection_method(self.queue.teamSelection)

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -204,6 +204,7 @@ class Game:
     async def process_team_selection_method(self, team_selection=None):
         if not team_selection:
             team_selection = self.teamSelection
+        self.reset_players()
         team_selection = team_selection.lower()
         helper_role = self.helper_role
         if team_selection == Strings.VOTE_TS.lower():

--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -329,18 +329,18 @@ class Game:
         
         # Check if Teams are determined
         teams_finalized = False
-        if len(self.orange) == self.queue.maxSize/2:
+        if len(self.orange) == self.queue.maxSize//2:
             self.blue.update(self.players)
             teams_finalized = True
-        elif len(self.blue) == self.queue.maxSize/2:
+        elif len(self.blue) == self.queue.maxSize//2:
             self.orange.update(self.players)
             teams_finalized = True
         
         if teams_finalized:
             self.reset_players()
+            self.get_new_captains_from_teams()
             await self.update_game_info()
             await self._notify(Strings.ONGOING_GS)
-
 
     async def process_team_select_vote(self, emoji, member, added=True):
         if member not in self.players:

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -59,8 +59,10 @@ class SixMansQueue:
         return self.queue.qsize() >= self.queueMaxSize
 
     async def send_message(self, message='', embed=None):
+        messages = []
         for channel in self.channels:
-            await channel.send(message, embed=embed)
+            messages.append(await channel.send(message, embed=embed))
+        return messages
 
     async def set_team_selection(self, team_selection):
         self.teamSelection = team_selection

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -9,10 +9,11 @@ from .strings import Strings
 import discord
 
 SELECTION_MODES = {
-    0x1F3B2: Strings.RANDOM_TS,     # game_die
-    0x1F1E8: Strings.CAPTAINS_TS,   # C
-    0x0262F: Strings.BALANCED_TS,   # yin_yang
-    0x1F5F3: Strings.VOTE_TS        # ballot_box
+    0x1F3B2: Strings.RANDOM_TS,         # game_die
+    0x1F1E8: Strings.CAPTAINS_TS,       # C
+    0x0262F: Strings.BALANCED_TS,       # yin_yang
+    0x1F530: Strings.SELF_PICKING_TS,   # beginner
+    0x1F5F3: Strings.VOTE_TS            # ballot_box
 }
 
 class SixMansQueue:
@@ -102,7 +103,6 @@ class SixMansQueue:
             "Category": category_id,
             "LobbyVC": lobby_vc_id
         }
-
 
 class PlayerQueue(Queue):
     def _init(self, maxsize):

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -12,12 +12,12 @@ SELECTION_MODES = {
     0x1F3B2: Strings.RANDOM_TS,     # game_die
     0x1F1E8: Strings.CAPTAINS_TS,   # C
     0x0262F: Strings.BALANCED_TS,   # yin_yang
-    0x0FE0F: Strings.VOTE_TS        # ballot_box
+    0x1F5F3: Strings.VOTE_TS        # ballot_box
 }
 
 class SixMansQueue:
     def __init__(self, name, guild: discord.Guild, channels: List[discord.TextChannel],
-        points, players, gamesPlayed, queueMaxSize, teamSelection=Strings.RANDOM_TS, category: discord.CategoryChannel=None,):
+        points, players, gamesPlayed, maxSize, teamSelection=Strings.RANDOM_TS, category: discord.CategoryChannel=None, lobby_vc: discord.VoiceChannel=None):
         self.id = uuid.uuid4().int
         self.name = name
         self.queue = PlayerQueue()
@@ -26,8 +26,10 @@ class SixMansQueue:
         self.points = points
         self.players = players
         self.gamesPlayed = gamesPlayed
-        self.queueMaxSize = queueMaxSize
+        self.maxSize = maxSize
         self.teamSelection = teamSelection
+        self.category = category
+        self.lobby_vc = lobby_vc
         self.activeJoinLog = {}
 
     def _put(self, player):
@@ -56,7 +58,7 @@ class SixMansQueue:
             pass
 
     def _queue_full(self):
-        return self.queue.qsize() >= self.queueMaxSize
+        return self.queue.qsize() >= self.maxSize
 
     async def send_message(self, message='', embed=None):
         messages = []
@@ -87,13 +89,18 @@ class SixMansQueue:
             return None
 
     def _to_dict(self):
+        lobby_vc_id = self.lobby_vc.id if self.lobby_vc else None
+        category_id = self.category.id if self.category else None
         return {
             "Name": self.name,
             "Channels": [x.id for x in self.channels],
             "Points": self.points,
             "Players": self.players,
             "GamesPlayed": self.gamesPlayed,
-            "TeamSelection": self.teamSelection
+            "TeamSelection": self.teamSelection,
+            "MaxSize": self.maxSize,
+            "Category": category_id,
+            "LobbyVC": lobby_vc_id
         }
 
 

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -32,10 +32,11 @@ class SixMansQueue:
         self.category = category
         self.lobby_vc = lobby_vc
         self.activeJoinLog = {}
+        # TODO: active join log could maintain queue during downtime
 
     def _put(self, player):
         self.queue.put(player)
-        self.activeJoinLog[player.id] = datetime.datetime.now()
+        # self.activeJoinLog[player.id] = datetime.datetime.now()
 
     def _get(self):
         player = self.queue.get()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -786,7 +786,7 @@ class SixMans(commands.Cog):
     @commands.command(aliases=["cq", "status"])
     async def checkQueue(self, ctx: Context):
         six_mans_queue = self._get_queue_by_text_channel(ctx.channel)
-        if six_mans_queue is None:
+        if not six_mans_queue:
             await ctx.send(":x: No queue set up in this channel")
             return
         await ctx.send(embed=self.embed_queue_players(six_mans_queue))
@@ -1031,7 +1031,7 @@ class SixMans(commands.Cog):
         if invite:
             invite_msg = "\n\n[Click here to revisit the queue!]({})".format(invite.url)
             embed = discord.Embed(
-                title="{} Mans Timeout".format(six_mans_queue.maxSize),
+                title="{}: {} Mans Timeout".format(six_mans_queue.guild.name, six_mans_queue.maxSize),
                 description=auto_remove_msg + invite_msg,
                 color=discord.Color.red()
             )
@@ -1434,7 +1434,7 @@ class SixMans(commands.Cog):
     def embed_queue_players(self, queue: SixMansQueue):
         player_list = self.format_player_list(queue)
         embed = discord.Embed(title="{0} {1} Mans Queue".format(queue.name, queue.maxSize), color=discord.Colour.blue())
-        embed.add_field(name="Players in Queue", value=player_list, inline=False)
+        embed.add_field(name="Players in Queue ({}/{})".format(len(queue.queue.queue), queue.maxSize), value=player_list, inline=False)
         return embed
 
     def embed_active_games(self, guild, queueGames: Dict[int, List[Game]]):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1338,7 +1338,7 @@ class SixMans(commands.Cog):
 
         # Find Game
         game = self._get_game_by_text_channel(channel)
-        
+        game: Game
         if not game:
             return False
         if message != game.info_message:
@@ -1351,6 +1351,9 @@ class SixMans(commands.Cog):
 
         elif team_selection_mode == Strings.CAPTAINS_TS.lower():
             await game.process_captains_pick(emoji, user)
+        
+        elif team_selection_mode == Strings.SELF_PICKING_TS.lower():
+            await game.process_self_picking_teams(emoji, user, True)
 
         elif team_selection_mode == Strings.SHUFFLE_TS.lower():
             if emoji is not Strings.SHUFFLE_REACT:
@@ -1380,15 +1383,17 @@ class SixMans(commands.Cog):
         # on_raw_reaction_add
         if type(emoji) == discord.partial_emoji.PartialEmoji:
             emoji = emoji.name
-
         try:
             game = self._get_game_by_text_channel(channel)
-
+            game: Game 
             if not game:
                 return False
 
             if game.teamSelection.lower() == Strings.VOTE_TS.lower():
                 await game.process_team_select_vote(emoji, user, added=False)
+            
+            elif game.teamSelection.lower() == Strings.SELF_PICKING_TS.lower():
+                await game.process_self_picking_teams(emoji, user, False)
         except:
             pass
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -32,7 +32,7 @@ defaults = {
     "CategoryChannel": None,
     "HelperRole": None,
     "AutoMove": False,
-    "ReactToVote": False,
+    "ReactToVote": True,
     "QLobby": None,
     "DefaultTeamSelection": Strings.RANDOM_TS,
     "DefaultQueueMaxSize": 6,
@@ -70,13 +70,14 @@ class SixMans(commands.Cog):
     @commands.command()
     @checks.admin_or_permissions(manage_guild=True)
     async def clearSixMansData(self, ctx: Context):
-        msg = await ctx.send("{0} Please verify that you wish to clear **all** of the {1} Mans data.".format(ctx.author.mention, self.queueMaxSize[ctx.guild]))
+        msg = await ctx.send("{0} Please verify that you wish to clear **all** of the {1} Mans data for the guild.".format(ctx.author.mention, self.queueMaxSize[ctx.guild]))
         start_adding_reactions(msg, ReactionPredicate.YES_OR_NO_EMOJIS)
 
         pred = ReactionPredicate.yes_or_no(msg, ctx.author)
         await ctx.bot.wait_for("reaction_add", check=pred)
-        if pred.result is True:
-            await self.config.clear_all_guilds()
+        if pred.result:
+            # await self.config.clear_all_guilds()
+            await self._clear_all_data(ctx.guild)
             await ctx.send("Done")
         else:
             await ctx.send(":x: Data **not** cleared.")
@@ -1585,6 +1586,21 @@ class SixMans(commands.Cog):
                 game_list.append(game)
             
             self.games[guild] = game_list
+
+    async def _clear_all_data(self, guild: discord.Guild):
+        await self._save_games(guild, [])
+        await self._save_queues(guild, [])
+        await self._save_scores(guild, [])
+        await self._save_games_played(guild, 0)
+        await self._save_players(guild, {})
+        await self._save_category(guild, None)
+        await self._save_q_lobby_vc(guild, None)
+        await self._save_queue_max_size(guild, 6)
+        await self._save_helper_role(guild, None)
+        await self._save_team_selection(guild, Strings.RANDOM_TS)
+        await self._save_react_to_vote(guild, True)
+        await self._save_automove(guild, False)
+
 
     async def _games(self, guild: discord.Guild):
         return await self.config.guild(guild).Games()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -14,7 +14,7 @@ from .game import Game
 from .queue import SixMansQueue
 from .strings import Strings
 
-DEBUG = True
+DEBUG = False
 MINIMUM_GAME_TIME = 600                         # Seconds (10 Minutes)
 PLAYER_TIMEOUT_TIME = 10 if DEBUG else 14400    # How long players can be in a queue in seconds (4 Hours)
 LOOP_TIME = 5                                   # How often to check the queues in seconds
@@ -174,7 +174,6 @@ class SixMans(commands.Cog):
         seconds = minutes*60
         await self._save_player_timeout(ctx.guild, seconds)
         self.player_timeout_time[ctx.guild] = seconds
-
         s_if_plural = "" if minutes == 1 else "s"
         await ctx.send(":white_check_mark: Players in Six Mans Queues will now be timed out after **{} minute{}**.".format(minutes, s_if_plural))
         
@@ -1618,6 +1617,7 @@ class SixMans(commands.Cog):
         await self._save_category(guild, None)
         await self._save_q_lobby_vc(guild, None)
         await self._save_queue_max_size(guild, 6)
+        await self._save_player_timeout(guild, PLAYER_TIMEOUT_TIME)
         await self._save_helper_role(guild, None)
         await self._save_team_selection(guild, Strings.RANDOM_TS)
         await self._save_react_to_vote(guild, True)

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -190,6 +190,7 @@ class SixMans(commands.Cog):
     @commands.command(aliases=['setQueueSize', 'setQMaxSize', 'setQMS', 'sqms'])
     @checks.admin_or_permissions()
     async def setQueueMaxSize(self, ctx: Context, max_size: int):
+        """Sets the max size for all queues in the guild. (Default: 6)"""
         if max_size <= 2:
             return await ctx.send(":x: Queues sizes must be 4+.")
         if max_size % 2 == 1:
@@ -205,6 +206,7 @@ class SixMans(commands.Cog):
     @commands.command(aliases=['getQMaxSize', 'getQMS', 'gqms', 'qms'])
     @checks.admin_or_permissions()
     async def getQueueMaxSize(self, ctx: Context):
+        """Gets the max size for all queues in the guild. (Default: 6)"""
         guild_queue_size = await self._get_queue_max_size(ctx.guild)
         await ctx.send("Default Queue Size: {}".format(guild_queue_size))
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1098,38 +1098,6 @@ class SixMans(commands.Cog):
                 del self.timeout_tasks[player]
         except:
             pass
-
-    # TODO: remove
-    async def timeout_queues(self):
-        """Loop task that checks if any players in a queue have been in there longer than the max queue time and need to be timed out."""
-        await self.bot.wait_until_ready()
-        while self.bot.get_cog("SixMans") == self:
-            deadline = datetime.datetime.now() - datetime.timedelta(seconds=PLAYER_TIMEOUT_TIME)           
-            for guild in self.bot.guilds:
-                for queue in self.queues[guild]:
-                    players_to_remove = []
-                    ids_to_remove = []
-                    for player_id, join_time in queue.activeJoinLog.items():
-                        if join_time < deadline:
-                            try:
-                                player = self.bot.get_user(player_id)
-                                if player:
-                                    players_to_remove.append(player)
-                                else:
-                                    # Can't see the user (no shared servers)
-                                    ids_to_remove.append(player_id)  
-                            except discord.HTTPException:
-                                pass
-                            except:
-                                ids_to_remove.append(player_id)
-                    for player in players_to_remove:
-                        await self._auto_remove_from_queue(player, queue)
-                    for player_id in ids_to_remove:
-                        try:
-                            del queue.activeJoinLog[player_id]
-                        except:
-                            pass
-                await asyncio.sleep(LOOP_TIME)
             
     async def _finish_game(self, guild: discord.Guild, game: Game, six_mans_queue: SixMansQueue, winning_team):
         winning_players = []

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -167,7 +167,7 @@ class SixMans(commands.Cog):
             await ctx.send(":x: **{}** is not a valid team selection method.".format(team_selection))
 
     @commands.guild_only()
-    @commands.command(aliases=['setQTO', 'sqto'])
+    @commands.command(aliases=['setQTimeout', 'setQTO', 'sqto'])
     @checks.admin_or_permissions()
     async def setQueueTimeout(self, ctx: Context, minutes: int):
         """Sets the player timeout in minutes for queues in the guild (Default: 240) ."""
@@ -712,7 +712,7 @@ class SixMans(commands.Cog):
     #region rank commands
 
     @commands.guild_only()
-    @commands.group(aliases=["rnk"])
+    @commands.group(aliases=["rnk", "playerCard", "pc"])
     async def rank(self, ctx: Context):
         """Get your rank in points, wins, and games played for the specific queue. If no queue name is given it will show your overall rank across all queues."""
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -617,6 +617,7 @@ class SixMans(commands.Cog):
 
         queue = await self._get_queue_by_name(ctx.guild, queue_name) if queue_name else None
         queue_id = queue.id if queue else None
+        queue_name = queue.name if queue else ctx.guild.name
         day_ago = datetime.datetime.now() - datetime.timedelta(days=1)
         players, games_played = self._filter_scores(ctx.guild, scores, day_ago, queue_id)
 
@@ -624,7 +625,6 @@ class SixMans(commands.Cog):
             await ctx.send(":x: Queue leaderboard not available for {0}".format(queue_name))
             return
 
-        queue_name = queue.name if queue else ctx.guild.name
         sorted_players = self._sort_player_dict(players)
         await ctx.send(embed=await self.embed_leaderboard(ctx, sorted_players, queue, games_played, "Daily"))
 

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -16,7 +16,7 @@ from .strings import Strings
 
 DEBUG = True
 MINIMUM_GAME_TIME = 600                         # Seconds (10 Minutes)
-PLAYER_TIMEOUT_TIME = 2 if DEBUG else 14400    # How long players can be in a queue in seconds (4 Hours)
+PLAYER_TIMEOUT_TIME = 10 if DEBUG else 14400    # How long players can be in a queue in seconds (4 Hours)
 LOOP_TIME = 5                                   # How often to check the queues in seconds
 VERIFY_TIMEOUT = 15                             # How long someone has to react to a prompt (seconds)
 CHANNEL_SLEEP_TIME = 5 if DEBUG else 30         # How long channels will persist after a game's score has been reported (seconds)
@@ -225,7 +225,7 @@ class SixMans(commands.Cog):
                 game_id = None
                 team_selection = ' '.join(args)
 
-        game = None
+        game: Game = None
         if game_id:
             for active_game in self.games[ctx.guild]:
                 if active_game.id == game_id:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -1026,7 +1026,7 @@ class SixMans(commands.Cog):
 
     async def create_invite(self, channel: discord.TextChannel, retry=0, retry_max=3):
         try:
-            return await channel.create_invite()
+            return await channel.create_invite(temporary=True) # , max_uses=1, ) # max_age=86400)
         except discord.HTTPException:
             # Try x more times
             if retry <= retry_max:

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -212,7 +212,6 @@ class SixMans(commands.Cog):
         if not await self.has_perms(ctx.author):
             return
 
-        
         if len(args) == 1:
             game_id = None
             team_selection = args

--- a/sixMans/strings.py
+++ b/sixMans/strings.py
@@ -26,7 +26,7 @@ class Strings:
     # Game states
     TEAM_SELECTION_GS = "team selection"
     ONGOING_GS = "ongoing"
-    CANCELED_GS = "cancelled"
+    CANCELED_GS = "canceled"
     GAME_OVER_GS = "game over"
 
     # Lobby Info

--- a/sixMans/strings.py
+++ b/sixMans/strings.py
@@ -20,11 +20,13 @@ class Strings:
     SHUFFLE_REACT = "\U0001F500"                # :twisted_rightwards_arrows:
     WHITE_X_REACT = "\U0000274E"                # :negative_squared_cross_mark:
     WHITE_CHECK_REACT = "\U00002705"            # :white_check_mark:
+    BLUE_REACT = 0x1F535                        # :blue_circle:
+    ORANGE_REACT = 0x1F7E0                      # :orange_circle:    
 
     # Game states
     TEAM_SELECTION_GS = "team selection"
     ONGOING_GS = "ongoing"
-    CANCELED_GS = "canceled"
+    CANCELED_GS = "cancelled"
     GAME_OVER_GS = "game over"
 
     # Lobby Info

--- a/sixMans/strings.py
+++ b/sixMans/strings.py
@@ -13,6 +13,7 @@ class Strings:
     RANDOM_TS = 'Random'
     SHUFFLE_TS = 'Shuffle'
     CAPTAINS_TS = 'Captains'
+    SELF_PICKING_TS = 'Self Picking Teams'
     BALANCED_TS = 'Balanced (beta)'
 
     # Reactions

--- a/sixMans/strings.py
+++ b/sixMans/strings.py
@@ -8,6 +8,7 @@ class Strings:
     PLAYER_WINS_KEY = "Wins"
 
     # Team Selection
+    DEFAULT_TS = 'Default'
     VOTE_TS = 'Vote'
     RANDOM_TS = 'Random'
     SHUFFLE_TS = 'Shuffle'
@@ -22,6 +23,7 @@ class Strings:
     # Game states
     TEAM_SELECTION_GS = "team selection"
     ONGOING_GS = "ongoing"
+    CANCELED_GS = "canceled"
     GAME_OVER_GS = "game over"
 
     # Lobby Info


### PR DESCRIPTION
## Six Mans - High Level
- Enables Six Mans to be run on multiple guilds simultaneously
- Adds 🔰 **Self Picking Teams** team selection option
- Replaces polling timeouts with async timeout tasks
- Adds `<p>forceTeamSelection` command, or `<p>fts`
- Replaces timeout message with an embed message, with a hyperlink (temporary invitation) to the queue channel
- `<p>clearSixMansData` is now guild-specific, rather than clearing data for all guilds
- `<p>setQueueTimeout` allows admins to set the amount of time (in minutes) before a player is de-queued from the Six Mans Queue. `<p>getQueueTimeout` was added as an accessor command.
- `<p>setQueueMaxSize` allows a customized queue size for queues in the guild. `<p>getQueueMaxSize` was added as an accessor command.

## Six Mans - Detailed
- Converts queues and games from array to dictionary with guild as key
- Tracks `player_timeout_tasks` and updates when a player is added to or removed from a queue, or when cog is unloaded
- Removes `timeout_queues` function, and disables `queue.activeJoinLog` dictionary
- Replaces `_pre_load_queues` and `_pre_load_games` with a single `_pre_load_data`, which is executed upon `__init__` function
- Removes queue id/name accessor methods with get queue accessor method
- Disables `on_reaction_add` and `on_reaction_remove` => only uses raw reaction events
- Fixes ballot box emoji code
- Adds `cancelled` game state
- Includes a hyperlink (temporary `guild.channel` invite) to queue text channel in timeout embed message
- `add_to_<color>` removes a player from `players` and the opposing team if they are on it.
- Adds helper/skeleton code for default team selection and team selection commands
- Renames `SixMansQueue.queueMaxSize` to `SixMansQueue.maxSize`
- Saves category, `lobby_vc` to guild
- Saves `use_reactions` to game
- Update status command to include player count/total (i.e. 5/6)
- Adds aliases `<p>playerCard` and `<p>pc` to `<p>rank` command
- Updates `sixMans` readme

## Embed Screenshots
**Note:** "TeamsTesting" is the name of the guild where these tests have been made. The thumbnail of the following embeds is the guild 
### Team Selection | Self-Picking Teams
![image](https://user-images.githubusercontent.com/16944592/125563645-86a1008a-2237-4078-918e-7dbb342b63f1.png)

### De-Queue DM
![image](https://user-images.githubusercontent.com/16944592/125563689-20225f6b-8066-49c0-82ae-4498f7eb17b2.png)
