### PR TITLE
Fix Six Mans

### DIFF
--- a/sixMans/game.py
+++ b/sixMans/game.py
@@ -261,7 +261,7 @@ class Game:
 
         # RECORD VOTES
         votes = {}
-        self.info_message = await self.textChannel.fetch_message(self.info_message.id)
+        self.info_message = await self.textChannel.fetch_message(self.info_message.id) # this is needed to get the up to date reactions for a message
         for this_react in self.info_message.reactions:
             react_hex_i = self._hex_i_from_emoji(this_react.emoji)
             if react_hex_i in SELECTION_MODES:
@@ -611,6 +611,7 @@ class Game:
     def _to_dict(self):
         info_msg = self.info_message.id if self.info_message else None
         txt_channel = self.textChannel.id if self.textChannel else None
+        helper_role = self.helper_role.id if self.helper_role else None
         try:
             vc_channels = [x.id for x in self.voiceChannels]
         except:
@@ -627,7 +628,7 @@ class Game:
             "VoiceChannels": vc_channels,
             "QueueId": self.queue.id,
             "ScoreReported": self.scoreReported,
-            "HelperRole": self.helper_role.id,
+            "HelperRole": helper_role,
             "TeamSelection": self.teamSelection,
             "InfoMessage": info_msg,
             "State": self.game_state

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -59,8 +59,10 @@ class SixMansQueue:
         return self.queue.qsize() >= self.queueMaxSize
 
     async def send_message(self, message='', embed=None):
+        messages = []
         for channel in self.channels:
-            await channel.send(message, embed=embed)
+            messages.append(await channel.send(message, embed=embed))
+        return messages
 
     async def set_team_selection(self, team_selection):
         self.teamSelection = team_selection

--- a/sixMans/queue.py
+++ b/sixMans/queue.py
@@ -91,19 +91,21 @@ class SixMansQueue:
             return None
 
     def _to_dict(self):
-        lobby_vc_id = self.lobby_vc.id if self.lobby_vc else None
-        category_id = self.category.id if self.category else None
-        return {
+        q_data = {
             "Name": self.name,
             "Channels": [x.id for x in self.channels],
             "Points": self.points,
             "Players": self.players,
             "GamesPlayed": self.gamesPlayed,
             "TeamSelection": self.teamSelection,
-            "MaxSize": self.maxSize,
-            "Category": category_id,
-            "LobbyVC": lobby_vc_id
+            "MaxSize": self.maxSize
         }
+        if self.category:
+            q_data['Category'] = self.category.id
+        if self.lobby_vc:
+            q_data['LobbyVC'] = self.lobby_vc.id
+        
+        return q_data
 
 class PlayerQueue(Queue):
     def _init(self, maxsize):

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -839,11 +839,14 @@ class SixMans(commands.Cog):
         await ctx.send(embed=self.embed_queue_players(six_mans_queue))
 
     @commands.guild_only()
-    @commands.command(aliases=["setQLobby"])
+    @commands.command(aliases=["setQLobby", "setQVC"])
     @checks.admin_or_permissions(manage_guild=True)
     async def setQueueLobby(self, ctx: Context, lobby_voice: discord.VoiceChannel):
         #TODO: Consider having the queues save the Queue Lobby VC
+        for queue in self.queues[ctx.guild]:
+            queue.lobby_vc = lobby_voice
         await self._save_q_lobby_vc(ctx.guild, lobby_voice.id)
+        await self._save_queues(ctx.guild, self.queues[ctx.guild])
         await ctx.send("Done")
     
     @commands.guild_only()

--- a/sixMans/sixMans.py
+++ b/sixMans/sixMans.py
@@ -927,16 +927,13 @@ class SixMans(commands.Cog):
         - **random**: selects random teams
         - **captains**: selects a captain for each team
         - **vote**: players vote for team selection method after queue pops
-        - ~~**balanced**: creates balanced teams from all participating players~~
+        - **balanced (beta)**: creates balanced teams from all participating players
         - ~~**shuffle**: selects random teams, but allows re-shuffling teams after they have been set~~
         """
         # TODO: Support Captains [captains random, captains shuffle], Balanced
-        team_selection_method = team_selection_method.lower()
+        team_selection_method = team_selection_method.title()
         if team_selection_method not in QTS_METHODS:
             return await ctx.send("**{}** is not a valid method of team selection.".format(team_selection_method))
-
-        if team_selection_method in ['vote', 'balanced']:
-            return await ctx.send("**{}** is not currently supported as a method of team selection.".format(team_selection_method))
         
         await self._save_team_selection(ctx.guild, team_selection_method)
 


### PR DESCRIPTION
- gives move members permissions to six mans helper roles
- updates `to_dict` for SixMansQueue class so that an error isn't thrown when checking if a `lobby_vc` or `category` is defined
- saves queues after lobby is set.
- Adds "Done" message to `<p>setQueueMaxSize`
- Adds `<p>preLoadData` command

Bug explanation:
- The `to_dict` saved the lobby vc, and the category in a one-line if statement, which failed upon the condition, checking for the id before it knew whether or not the variable itself was defined or not, so having no `lobby_vc` defined, lead `_save_queues` to fail every time. `_save_queues` is executed on score reports AND on `setQLobby`, so it couldn't be fixed because setting the queue vc lobby would only save to the db without setting it in the active variable, so any time `_save_queues` would be executed, it would be overwritten.