### PR TITLE
Stat Manager

### DIFF
--- a/statsManager/__init__.py
+++ b/statsManager/__init__.py
@@ -1,0 +1,4 @@
+from .statsManager import StatsManager
+
+def setup(bot):
+    bot.add_cog(StatsManager(bot))

--- a/statsManager/statsManager.py
+++ b/statsManager/statsManager.py
@@ -1,0 +1,40 @@
+from sys import prefix
+from typing import NewType
+import discord
+import re
+import ast
+import asyncio
+import difflib
+
+from redbot.core import Config
+from redbot.core import commands
+from redbot.core import checks
+from collections import Counter
+from redbot.core.utils.predicates import MessagePredicate
+from redbot.core.utils.predicates import ReactionPredicate
+from redbot.core.utils.menus import start_adding_reactions
+
+
+defaults = {"url": None}
+verify_timeout = 30
+
+
+class StatsManager(commands.Cog):
+    """Enables access to Player and Team Stats"""
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(self, identifier=1234567892, force_registration=True)
+        self.config.register_guild(**defaults)
+        self.prefix_cog = bot.get_cog("TeamManager")
+
+# region Admin Commands
+    @commands.command(aliases=['setURL', 'seturl'])
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setUrl(self, ctx, tier_name: str):
+        pass 
+
+# region General Commands
+
+# JSON
+

--- a/statsManager/statsManager.py
+++ b/statsManager/statsManager.py
@@ -1,4 +1,5 @@
 from sys import prefix
+from turtle import pd
 from typing import NewType
 import discord
 import re
@@ -13,11 +14,16 @@ from collections import Counter
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.predicates import ReactionPredicate
 from redbot.core.utils.menus import start_adding_reactions
+from discord.ext.commands import Context
+
+import requests
+from teamManager import TeamManager
 
 
-defaults = {"url": None}
+defaults = {"BaseUrl": None, "LeagueHeader": None}
 verify_timeout = 30
 
+DONE = "Done"
 
 class StatsManager(commands.Cog):
     """Enables access to Player and Team Stats"""
@@ -25,16 +31,145 @@ class StatsManager(commands.Cog):
         self.bot = bot
         self.config = Config.get_conf(self, identifier=1234567892, force_registration=True)
         self.config.register_guild(**defaults)
-        self.prefix_cog = bot.get_cog("TeamManager")
+        self.team_manager : TeamManager = bot.get_cog("TeamManager")
+
+        asyncio.create_task(self._pre_load_data())
 
 # region Admin Commands
     @commands.command(aliases=['setURL', 'seturl'])
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def setUrl(self, ctx, tier_name: str):
-        pass 
+    async def setUrl(self, ctx: Context, base_url: str):
+        if 'https://' not in base_url:
+            base_url = f"https://{base_url}"
+        await self._save_url(ctx.guild, base_url)
+        await ctx.send(DONE)
+    
+    @commands.command()
+    @commands.guild_only()
+    @checks.admin_or_permissions(manage_guild=True)
+    async def setLeagueHeader(self, ctx: Context, league_header: str):
+        await self._save_url(ctx.guild, league_header)
+        await ctx.send(DONE)
+
+# endregion
 
 # region General Commands
+    @commands.command(aliases=['setURL', 'seturl'])
+    @commands.guild_only()
+    async def playerStats(self, ctx, player: discord.Member=None):
+        if not player:
+            player = ctx.author
+        
+        team = (await self.team_manager.teams_for_user(ctx, player))[0]
+        stats = await self.get_player_stats(ctx.guild, player, team)
+        embed = self.get_player_stats_embed(ctx, player, stats)
 
-# JSON
+        await ctx.send(embed=embed)
 
+# endregion
+
+# region Helper Commands
+    async def _pre_load_data(self):
+        await self.bot.wait_until_ready()
+        self.base_urls = {}
+        self.league_headers = {}
+
+        for guild in self.bot.guilds:
+            self.base_urls[guild] = await self.get_url(guild)
+            self.league_headers[guild] = await self.get_league_header(guild)
+    
+    async def get_player_stats(self, guild: discord.Guild, player: discord.Member, team: str):
+        if not self.base_urls.get(guild, False):
+            return None
+        
+        full_url = f"{self.base_urls[guild]}/players/{team}"
+        
+        loop = asyncio.get_event_loop()
+        future = loop.run_in_executor(
+            None, lambda: requests.get(
+                full_url,
+                headers={'League': self.league_headers[guild]}
+            )
+        )
+        response = await future
+
+        data = response.json()
+
+        player_name = self.get_name_components(player)[1]
+        player_data = {}
+        for p_data in data:
+            if p_data.get('playerName', '') == player_name:
+                player_data = p_data
+                break
+
+        return player_data
+    
+    async def get_player_stats_embed(self, ctx, player, team, stats):
+        player_name = self.get_name_components(player)[1]
+        franchise_role, tier_role = await self.team_manager._roles_for_team(ctx, team)
+
+        embed = discord.Embed(title=f"{player_name} Player Stats", color=tier_role.color)
+
+        emoji = await self.team_manager._get_franchise_emoji(ctx, franchise_role)
+        if emoji:
+            embed.set_thumbnail(url=emoji.url)
+        else:
+            embed.set_thumbnail(url=ctx.guild.icon_url)
+        
+        include_stats = ["GP", "GW", "GL", "wPct", "pts", "goals", "assists", "saves", "shots", "shotPct", "ppg", "cycles", "hatTricks", "playmakers", "saviors"]
+        for stat in include_stats:
+            stat_title = self.get_stat_title(stat)
+            embed.add_field(name=stat_title, value=stats.get(include_stats, "N/A")) # , inline=False)
+        
+        return embed
+    
+    def get_stat_title(self, stat_code):
+        stat_code_titles = {
+            "gp": "GP",
+            "hattricks": "Hat Tricks",
+            "playmakers": "Play Makers",
+            "goals": "Goals",
+            "assists": "Assists",
+            "shots": "Shots",
+            "cycles": "Cycles"
+        }
+        return stat_code_titles.get(stat_code.lower(), stat_code)
+
+    def get_name_components(self, member: discord.Member):
+        if member.nick:
+            name = member.nick
+        else:
+            return "", member.name, ""
+        prefix = name[0:name.index(' | ')] if ' | ' in name else ''
+        if prefix:
+            name = name[name.index(' | ')+3:]
+        player_name = ""
+        awards = ""
+        for char in name[::-1]:
+            if char not in self.LEAGUE_AWARDS:
+                break
+            awards = char + awards
+
+        player_name = name.replace(" " + awards, "") if awards else name
+
+        return prefix.strip(), player_name.strip(), awards.strip()
+
+# endregion 
+
+# region JSON
+    async def _save_url(self, guild: discord.Guild, url):
+        await self.config.guild(guild).BaseUrl.set(url)
+        self.base_urls[guild] = url
+
+    async def get_url(self, guild: discord.Guild):
+        return await self.config.guild(guild).BaseUrl()
+
+    async def _save_league_header(self, guild: discord.Guild, league_header):
+        await self.config.guild(guild).LeagueHeader.set(league_header)
+        self.league_headers[guild] = league_header
+
+    async def get_league_header(self, guild: discord.Guild):
+        return await self.config.guild(guild).LeagueHeader()
+       
+# endregion

--- a/teamManager/teamManager.py
+++ b/teamManager/teamManager.py
@@ -748,8 +748,10 @@ class TeamManager(commands.Cog):
 
         embed = discord.Embed(description=message, color=tier_role.color)
         emoji = await self._get_franchise_emoji(ctx, franchise_role)
-        if(emoji):
+        if emoji:
             embed.set_thumbnail(url=emoji.url)
+        else:
+            embed.set_thumbnail(url=ctx.guild.icon_url)
         return embed
 
     async def format_roster_info(self, ctx, team_name: str):
@@ -820,8 +822,10 @@ class TeamManager(commands.Cog):
             "\n".join(captains_username)), inline=True)     # name = Username
 
         emoji = await self._get_franchise_emoji(ctx, franchise_role)
-        if(emoji):
+        if emoji:
             embed.set_thumbnail(url=emoji.url)
+        else:
+            embed.set_thumbnail(url=ctx.guild.icon_url)
         return embed
 
     async def _format_tier_captains(self, ctx, tier: str):
@@ -914,8 +918,10 @@ class TeamManager(commands.Cog):
             "\n".join(teams)), inline=True)
 
         emoji = await self._get_franchise_emoji(ctx, franchise_role)
-        if(emoji):
+        if emoji:
             embed.set_thumbnail(url=emoji.url)
+        else:
+            embed.set_thumbnail(url=ctx.guild.icon_url)
         return embed
 
     async def _format_teams_for_tier(self, ctx, tier):


### PR DESCRIPTION
- Updates `teamManager` to use guild icon in place of franchise logos where an emoji cannot be found
- Introduces `statManager` cog that can retrieve player stats in a standardized format from a specified url and "League" header
- `<p>playerStats <Member>` command will post embed of player stats

`statsManager` is untested, and may have failures.